### PR TITLE
feat: Creator Entity

### DIFF
--- a/src/main/java/croundteam/cround/creator/domain/Creator.java
+++ b/src/main/java/croundteam/cround/creator/domain/Creator.java
@@ -1,0 +1,29 @@
+package croundteam.cround.creator.domain;
+
+import croundteam.cround.creator.domain.platform.Platform;
+import croundteam.cround.member.domain.Member;
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@Table(uniqueConstraints = @UniqueConstraint(
+        name = "creator_member_unique",
+        columnNames="member_id"))
+public class Creator {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "creator_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", foreignKey = @ForeignKey(name = "fk_creator_to_member"))
+    private Member member;
+
+    @Embedded
+    private Platform platform;
+
+
+}

--- a/src/main/java/croundteam/cround/creator/domain/platform/Platform.java
+++ b/src/main/java/croundteam/cround/creator/domain/platform/Platform.java
@@ -1,0 +1,15 @@
+package croundteam.cround.creator.domain.platform;
+
+import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+
+@Embeddable
+public class Platform {
+
+    @Embedded
+    private PlatformUrl platformUrl;
+
+    @Embedded
+    private PlatformType platformType;
+
+}

--- a/src/main/java/croundteam/cround/creator/domain/platform/PlatformName.java
+++ b/src/main/java/croundteam/cround/creator/domain/platform/PlatformName.java
@@ -1,0 +1,14 @@
+package croundteam.cround.creator.domain.platform;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum PlatformName {
+    YOUTUBE("유튜브"),
+    INSTAGRAM("인스타그램"),
+    TIKTOK("틱톡"),
+    BLOG("블로그"),
+    PODCAST("팟캐스트");
+
+    private String title;
+}

--- a/src/main/java/croundteam/cround/creator/domain/platform/PlatformType.java
+++ b/src/main/java/croundteam/cround/creator/domain/platform/PlatformType.java
@@ -1,0 +1,14 @@
+package croundteam.cround.creator.domain.platform;
+
+import javax.persistence.Embeddable;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+
+@Embeddable
+public class PlatformType {
+
+    @Enumerated(EnumType.STRING)
+    private PlatformName platformName;
+
+
+}

--- a/src/main/java/croundteam/cround/creator/domain/platform/PlatformUrl.java
+++ b/src/main/java/croundteam/cround/creator/domain/platform/PlatformUrl.java
@@ -1,0 +1,4 @@
+package croundteam.cround.creator.domain.platform;
+
+public class PlatformUrl {
+}

--- a/src/main/java/croundteam/cround/member/domain/Member.java
+++ b/src/main/java/croundteam/cround/member/domain/Member.java
@@ -10,16 +10,20 @@ import javax.persistence.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = @UniqueConstraint(
+        name = "member_email_unique",
+        columnNames="email"))
 public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
     private Long id;
 
     @Column(nullable = false, length = 20)
     private String username;
 
-    @Column(nullable = false, length = 50, unique = true)
+    @Column(nullable = false, length = 50)
     private String email;
 
     @Column(length = 128)


### PR DESCRIPTION
## 기능 설명
외래 키(FK)와 유니크 키(Unique)를 지정한다.

## 기능 상세
- [x] `@Column` 애너테이션의 옵션으로 유니크 키를 지정할 경우 유니크 키의 이름이 알기 어려운 형태라 이름을 지정하여 설정
- [x] Member 멤버 <-> 크리에이터 Creator 의 관계가 1:1 이라 한쪽에 외래키를 두어야해서 정합성을 높이기 위해 외래키를 설정
- [x] 객체 중심적인 JPA의 특징을 살리기 위해 최대한 값 객체를 이용하여 엔티티를 설계
