### PR TITLE
feat: Platform, Creator, Tag Entity 생성

### DIFF
--- a/src/main/java/croundteam/cround/common/exception/ErrorCode.java
+++ b/src/main/java/croundteam/cround/common/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
 
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 E-mail입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
+    INVALID_PLATFORM_NAME(HttpStatus.BAD_REQUEST, "존재하지 않는 플랫폼 유형입니다."),
 
     NOT_EXIST_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.");
 

--- a/src/main/java/croundteam/cround/common/exception/tag/InvalidPlatformNameException.java
+++ b/src/main/java/croundteam/cround/common/exception/tag/InvalidPlatformNameException.java
@@ -1,0 +1,11 @@
+package croundteam.cround.common.exception.tag;
+
+import croundteam.cround.common.exception.BusinessException;
+import croundteam.cround.common.exception.ErrorCode;
+
+public class InvalidPlatformNameException extends BusinessException {
+
+    public InvalidPlatformNameException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/croundteam/cround/creator/domain/Creator.java
+++ b/src/main/java/croundteam/cround/creator/domain/Creator.java
@@ -1,16 +1,24 @@
 package croundteam.cround.creator.domain;
 
 import croundteam.cround.creator.domain.platform.Platform;
+import croundteam.cround.creator.domain.tag.CreatorTag;
 import croundteam.cround.member.domain.Member;
+import croundteam.cround.tag.domain.Tags;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Entity
 @Getter
 @Table(uniqueConstraints = @UniqueConstraint(
         name = "creator_member_unique",
         columnNames="member_id"))
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Creator {
 
     @Id
@@ -18,12 +26,25 @@ public class Creator {
     @Column(name = "creator_id")
     private Long id;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "member_id", foreignKey = @ForeignKey(name = "fk_creator_to_member"))
     private Member member;
 
     @Embedded
     private Platform platform;
 
+    @OneToMany(mappedBy = "creator", cascade = CascadeType.ALL)
+    List<CreatorTag> creatorTags = new ArrayList<>();
 
+    public Creator(Member member, Platform platform, Tags tags) {
+        this.member = member;
+        this.platform = platform;
+        this.creatorTags = castTagsToCreatorTags(tags);
+    }
+
+    private List<CreatorTag> castTagsToCreatorTags(Tags tags) {
+        return tags.toList().stream()
+                .map(tag -> CreatorTag.of(this, tag))
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/croundteam/cround/creator/domain/platform/Platform.java
+++ b/src/main/java/croundteam/cround/creator/domain/platform/Platform.java
@@ -1,9 +1,13 @@
 package croundteam.cround.creator.domain.platform;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.Embeddable;
 import javax.persistence.Embedded;
 
 @Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Platform {
 
     @Embedded
@@ -12,4 +16,8 @@ public class Platform {
     @Embedded
     private PlatformType platformType;
 
+    public Platform(PlatformUrl platformUrl, PlatformType platformType) {
+        this.platformUrl = platformUrl;
+        this.platformType = platformType;
+    }
 }

--- a/src/main/java/croundteam/cround/creator/domain/platform/PlatformName.java
+++ b/src/main/java/croundteam/cround/creator/domain/platform/PlatformName.java
@@ -1,14 +1,31 @@
 package croundteam.cround.creator.domain.platform;
 
-import lombok.AllArgsConstructor;
+import croundteam.cround.common.exception.ErrorCode;
+import croundteam.cround.common.exception.tag.InvalidPlatformNameException;
+import lombok.Getter;
 
-@AllArgsConstructor
+import javax.persistence.Column;
+
+@Getter
 public enum PlatformName {
     YOUTUBE("유튜브"),
     INSTAGRAM("인스타그램"),
     TIKTOK("틱톡"),
-    BLOG("블로그"),
     PODCAST("팟캐스트");
 
-    private String title;
+    @Column(name = "platform_name")
+    private String name;
+
+    PlatformName(String name) {
+        this.name = name;
+    }
+
+    public static PlatformName from(String platformName) {
+        try {
+            String type = platformName.trim().toUpperCase();
+            return PlatformName.valueOf(type);
+        } catch (IllegalArgumentException e) {
+            throw new InvalidPlatformNameException(ErrorCode.INVALID_PLATFORM_NAME);
+        }
+    }
 }

--- a/src/main/java/croundteam/cround/creator/domain/platform/PlatformType.java
+++ b/src/main/java/croundteam/cround/creator/domain/platform/PlatformType.java
@@ -1,14 +1,28 @@
 package croundteam.cround.creator.domain.platform;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 import javax.persistence.Embeddable;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 
 @Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlatformType {
 
     @Enumerated(EnumType.STRING)
     private PlatformName platformName;
 
+    public PlatformType(String platformName) {
+        this(PlatformName.from(platformName));
+    }
 
+    public PlatformType(PlatformName platformName) {
+        this.platformName = platformName;
+    }
+
+    public String getPlatformName() {
+        return platformName.getName();
+    }
 }

--- a/src/main/java/croundteam/cround/creator/domain/platform/PlatformUrl.java
+++ b/src/main/java/croundteam/cround/creator/domain/platform/PlatformUrl.java
@@ -1,4 +1,21 @@
 package croundteam.cround.creator.domain.platform;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlatformUrl {
+
+    @Column(name = "platform_url")
+    private String url;
+
+    public PlatformUrl(String url) {
+        this.url = url;
+    }
 }

--- a/src/main/java/croundteam/cround/creator/domain/tag/CreatorTag.java
+++ b/src/main/java/croundteam/cround/creator/domain/tag/CreatorTag.java
@@ -1,0 +1,37 @@
+package croundteam.cround.creator.domain.tag;
+
+import croundteam.cround.creator.domain.Creator;
+import croundteam.cround.tag.domain.Tag;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CreatorTag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "creator_tag_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "creator_id", foreignKey = @ForeignKey(name = "fk_creatortag_to_creator"))
+    private Creator creator;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @JoinColumn(name = "tag_id", foreignKey = @ForeignKey(name = "fk_creatortag_to_tag"))
+    private Tag tag;
+
+    public CreatorTag(Creator creator, Tag tag) {
+        this.creator = creator;
+        this.tag = tag;
+    }
+
+    public static CreatorTag of(Creator creator, Tag tag) {
+        return new CreatorTag(creator, tag);
+    }
+}

--- a/src/main/java/croundteam/cround/creator/repository/CreatorRepository.java
+++ b/src/main/java/croundteam/cround/creator/repository/CreatorRepository.java
@@ -1,0 +1,7 @@
+package croundteam.cround.creator.repository;
+
+import croundteam.cround.creator.domain.Creator;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CreatorRepository extends JpaRepository<Creator, Long> {
+}

--- a/src/main/java/croundteam/cround/member/controller/MemberController.java
+++ b/src/main/java/croundteam/cround/member/controller/MemberController.java
@@ -24,6 +24,6 @@ public class MemberController {
     @PostMapping
     public ResponseEntity<Void> join(@RequestBody @Valid MemberSaveRequest memberSaveRequest) {
         Long memberId = memberService.saveMember(memberSaveRequest);
-        return ResponseEntity.created(URI.create("api/members/" + memberId)).build();
+        return ResponseEntity.created(URI.create("/api/members/" + memberId)).build();
     }
 }

--- a/src/main/java/croundteam/cround/member/domain/Member.java
+++ b/src/main/java/croundteam/cround/member/domain/Member.java
@@ -1,9 +1,6 @@
 package croundteam.cround.member.domain;
 
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 

--- a/src/main/java/croundteam/cround/member/dto/MemberSaveRequest.java
+++ b/src/main/java/croundteam/cround/member/dto/MemberSaveRequest.java
@@ -2,7 +2,6 @@ package croundteam.cround.member.dto;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.ToString;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;

--- a/src/main/java/croundteam/cround/tag/domain/Tag.java
+++ b/src/main/java/croundteam/cround/tag/domain/Tag.java
@@ -1,0 +1,28 @@
+package croundteam.cround.tag.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Embedded
+    private TagName tagName;
+
+    public Tag(String tagName) {
+        this(TagName.from(tagName));
+    }
+
+    public Tag(TagName tagName) {
+        this.tagName = tagName;
+    }
+}

--- a/src/main/java/croundteam/cround/tag/domain/TagName.java
+++ b/src/main/java/croundteam/cround/tag/domain/TagName.java
@@ -1,0 +1,26 @@
+package croundteam.cround.tag.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class TagName {
+
+    // IN 절로 데이터 가져오기
+    @Column(name = "tag_name", nullable = false)
+    private String name;
+
+    public TagName(String name) {
+        this.name = name;
+    }
+
+    public static TagName from(String tagName) {
+        return new TagName(tagName);
+    }
+}

--- a/src/main/java/croundteam/cround/tag/domain/Tags.java
+++ b/src/main/java/croundteam/cround/tag/domain/Tags.java
@@ -1,0 +1,17 @@
+package croundteam.cround.tag.domain;
+
+import java.util.Collections;
+import java.util.List;
+
+public class Tags {
+
+    private List<Tag> tags;
+
+    public Tags(List<Tag> tags) {
+        this.tags = tags;
+    }
+
+    public List<Tag> toList() {
+        return Collections.unmodifiableList(tags);
+    }
+}

--- a/src/test/java/croundteam/cround/creator/domain/CreatorTest.java
+++ b/src/test/java/croundteam/cround/creator/domain/CreatorTest.java
@@ -1,0 +1,53 @@
+package croundteam.cround.creator.domain;
+
+import croundteam.cround.creator.domain.platform.Platform;
+import croundteam.cround.creator.domain.platform.PlatformType;
+import croundteam.cround.creator.domain.platform.PlatformUrl;
+import croundteam.cround.creator.repository.CreatorRepository;
+import croundteam.cround.member.domain.Member;
+import croundteam.cround.tag.domain.Tag;
+import croundteam.cround.tag.domain.Tags;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.Commit;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class CreatorTest {
+
+    @Autowired
+    CreatorRepository creatorRepository;
+
+    @Test
+    @DisplayName("Creator를 생성한다.")
+    @Commit
+    void create() {
+        // given
+        Member member = Member.builder()
+                .username("cround")
+                .password("password")
+                .email("cround@cround.com")
+                .build();
+        Platform platform = new Platform(new PlatformUrl("cround.com"), new PlatformType("Instagram"));
+        List<Tag> tagList = Arrays.asList(new Tag("크라운드 대표"), new Tag("크라운드 직원"));
+        Tags tags = new Tags(tagList);
+
+        // when
+        Creator creator = new Creator(member, platform, tags);
+        Creator saveCreator = creatorRepository.save(creator);
+
+        // then
+        Creator findCreator = creatorRepository.findById(saveCreator.getId()).get();
+        assertThat(findCreator).isNotNull();
+    }
+
+}


### PR DESCRIPTION
## 기능 설명
Platform, Creator, Tag Entity 생성

## 기능 상세
- [x] Platform Entity
- [x] Platform이 가지는 필드들(플랫폼 유형, 플랫폼 url)을 값 객체로 관리 (Validation 필요)
- [x] Creator Entity
- [x] Tag Entity
- [x] Tags(Based Tag) 일급 객체 생성
- [x] Creator 저장(EntityManager.save)시 관련 엔티티를 함께 저장하기 위해 Cascade.ALL 옵션 추가