### PR TITLE
feat: Follow Entity를 생성하고, Member와 Creator의 추가 정보들을 반영한다.

### DIFF
--- a/api/http/Member.http
+++ b/api/http/Member.http
@@ -4,7 +4,7 @@ Content-Type: application/json
 
 {
   "username": "크라운드",
-  "email": "croundcround.com",
+  "email": "cround@cround.com",
   "password": "cround",
   "confirmPassword": "cround"
 }

--- a/src/main/java/croundteam/cround/common/exception/ErrorCode.java
+++ b/src/main/java/croundteam/cround/common/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     INVALID_PLATFORM_NAME(HttpStatus.BAD_REQUEST, "존재하지 않는 플랫폼 유형입니다."),
     PROFILE_IMAGE_MATCH(HttpStatus.BAD_REQUEST, "설정된 프로필 이미지와 달라야 합니다."),
     PROFILE_IMAGE_EMPTY(HttpStatus.BAD_REQUEST, "입력된 프로필 이미지가 없습니다."),
+    INVALID_SOURCE_TARGET_FOLLOW(HttpStatus.BAD_REQUEST, "자기 자신을 팔로우 할 수 없습니다."),
 
     NOT_EXIST_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.");
 

--- a/src/main/java/croundteam/cround/common/exception/ErrorCode.java
+++ b/src/main/java/croundteam/cround/common/exception/ErrorCode.java
@@ -11,6 +11,8 @@ public enum ErrorCode {
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 E-mail입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     INVALID_PLATFORM_NAME(HttpStatus.BAD_REQUEST, "존재하지 않는 플랫폼 유형입니다."),
+    PROFILE_IMAGE_MATCH(HttpStatus.BAD_REQUEST, "설정된 프로필 이미지와 달라야 합니다."),
+    PROFILE_IMAGE_EMPTY(HttpStatus.BAD_REQUEST, "입력된 프로필 이미지가 없습니다."),
 
     NOT_EXIST_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.");
 

--- a/src/main/java/croundteam/cround/common/exception/member/InvalidSourceTargetFollowException.java
+++ b/src/main/java/croundteam/cround/common/exception/member/InvalidSourceTargetFollowException.java
@@ -1,0 +1,10 @@
+package croundteam.cround.common.exception.member;
+
+import croundteam.cround.common.exception.BusinessException;
+import croundteam.cround.common.exception.ErrorCode;
+
+public class InvalidSourceTargetFollowException extends BusinessException {
+    public InvalidSourceTargetFollowException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/croundteam/cround/common/exception/member/ProfileImageEmptyException.java
+++ b/src/main/java/croundteam/cround/common/exception/member/ProfileImageEmptyException.java
@@ -1,0 +1,10 @@
+package croundteam.cround.common.exception.member;
+
+import croundteam.cround.common.exception.BusinessException;
+import croundteam.cround.common.exception.ErrorCode;
+
+public class ProfileImageEmptyException extends BusinessException {
+    public ProfileImageEmptyException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/croundteam/cround/common/exception/member/ProfileImageEqualsException.java
+++ b/src/main/java/croundteam/cround/common/exception/member/ProfileImageEqualsException.java
@@ -1,0 +1,10 @@
+package croundteam.cround.common.exception.member;
+
+import croundteam.cround.common.exception.BusinessException;
+import croundteam.cround.common.exception.ErrorCode;
+
+public class ProfileImageEqualsException extends BusinessException {
+    public ProfileImageEqualsException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/croundteam/cround/creator/domain/Creator.java
+++ b/src/main/java/croundteam/cround/creator/domain/Creator.java
@@ -4,6 +4,7 @@ import croundteam.cround.common.domain.BaseTimeEntity;
 import croundteam.cround.creator.domain.platform.Platform;
 import croundteam.cround.creator.domain.tag.CreatorTag;
 import croundteam.cround.member.domain.Member;
+import croundteam.cround.member.domain.follow.Followers;
 import croundteam.cround.tag.domain.Tags;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -34,7 +35,10 @@ public class Creator extends BaseTimeEntity {
     @Embedded
     private Platform platform;
 
-    @OneToMany(mappedBy = "creator", cascade = CascadeType.ALL)
+    @Embedded
+    private Followers followers;
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "creator", cascade = CascadeType.ALL)
     List<CreatorTag> creatorTags = new ArrayList<>();
 
     public Creator(Member member, Platform platform, Tags tags) {

--- a/src/main/java/croundteam/cround/creator/domain/platform/Platform.java
+++ b/src/main/java/croundteam/cround/creator/domain/platform/Platform.java
@@ -17,8 +17,12 @@ public class Platform {
     @Embedded
     private PlatformType platformType;
 
-    public Platform(PlatformUrl platformUrl, PlatformType platformType) {
+    @Embedded
+    private PlatformActivityName platformActivityName;
+
+    public Platform(PlatformUrl platformUrl, PlatformType platformType, PlatformActivityName platformActivityName) {
         this.platformUrl = platformUrl;
         this.platformType = platformType;
+        this.platformActivityName = platformActivityName;
     }
 }

--- a/src/main/java/croundteam/cround/creator/domain/platform/PlatformActivityName.java
+++ b/src/main/java/croundteam/cround/creator/domain/platform/PlatformActivityName.java
@@ -1,0 +1,31 @@
+package croundteam.cround.creator.domain.platform;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlatformActivityName {
+
+    @Column(name = "activity_name")
+    private String name;
+
+    private PlatformActivityName(String name) {
+        this.name = name;
+    }
+
+    public static PlatformActivityName from(String name) {
+        validateName();
+        return new PlatformActivityName(name);
+    }
+
+    /**
+     * TODO: 금칙어 체크(Black-List) 로직
+     */
+    private static void validateName() {
+
+    }
+}

--- a/src/main/java/croundteam/cround/creator/domain/platform/PlatformType.java
+++ b/src/main/java/croundteam/cround/creator/domain/platform/PlatformType.java
@@ -14,13 +14,18 @@ public class PlatformType {
     @Enumerated(EnumType.STRING)
     private PlatformName platformName;
 
-    public PlatformType(String platformName) {
-        this(PlatformName.from(platformName));
-    }
-
-    public PlatformType(PlatformName platformName) {
+    private PlatformType(PlatformName platformName) {
         this.platformName = platformName;
     }
+
+    public static PlatformType from(String platformName) {
+        return new PlatformType(PlatformName.from(platformName));
+    }
+
+    public static PlatformType from(PlatformName platformName) {
+        return new PlatformType(platformName);
+    }
+
 
     public String getPlatformName() {
         return platformName.getName();

--- a/src/main/java/croundteam/cround/creator/domain/platform/PlatformUrl.java
+++ b/src/main/java/croundteam/cround/creator/domain/platform/PlatformUrl.java
@@ -15,7 +15,11 @@ public class PlatformUrl {
     @Column(name = "platform_url")
     private String url;
 
-    public PlatformUrl(String url) {
+    private PlatformUrl(String url) {
         this.url = url;
+    }
+
+    public static PlatformUrl from(String url) {
+        return new PlatformUrl(url);
     }
 }

--- a/src/main/java/croundteam/cround/member/domain/Member.java
+++ b/src/main/java/croundteam/cround/member/domain/Member.java
@@ -1,6 +1,9 @@
 package croundteam.cround.member.domain;
 
 import croundteam.cround.common.domain.BaseTimeEntity;
+import croundteam.cround.common.exception.ErrorCode;
+import croundteam.cround.common.exception.member.ProfileImageEmptyException;
+import croundteam.cround.common.exception.member.ProfileImageEqualsException;
 import croundteam.cround.member.domain.interest.Interest;
 import lombok.*;
 import org.springframework.beans.factory.annotation.Value;
@@ -51,18 +54,41 @@ public class Member extends BaseTimeEntity {
         this.role = Role.USER;
 
         this.nickname = createUUID();
-        this.profileImage = "https://avatars.githubusercontent.com/u/132455714?s=400&u=b9befff0d433aa7f0eaf9927a4e6f55af3fe9986&v=4";
-    }
-
-    private String createUUID() {
-        return UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+        this.profileImage = getDefaultProfileImage();
     }
 
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
 
+    public void updateProfileImage(String profileImage) {
+        validateProfileImage(profileImage);
+        /**
+         * TODO: 이미지를 변경한다. 이미지 변경 정책을 팀 회의때 얘기 나눈다.
+         * is null     >> 기본 프로필 이미지로 변경
+         * is not null >> 변경할 이미지로 변경
+         */
+    }
+
+    public void updateInterest(Interest interest) {
+        this.interest = interest;
+    }
+
+    private void validateProfileImage(String profileImage) {
+        if(this.profileImage.equals(profileImage)) {
+            throw new ProfileImageEqualsException(ErrorCode.PROFILE_IMAGE_MATCH);
+        }
+    }
+
     public String getRoleName() {
         return role.getName();
+    }
+
+    private String getDefaultProfileImage() {
+        return "https://avatars.githubusercontent.com/u/132455714?s=400&u=b9befff0d433aa7f0eaf9927a4e6f55af3fe9986&v=4";
+    }
+
+    private String createUUID() {
+        return UUID.randomUUID().toString().substring(0, 8).toUpperCase();
     }
 }

--- a/src/main/java/croundteam/cround/member/domain/Member.java
+++ b/src/main/java/croundteam/cround/member/domain/Member.java
@@ -1,9 +1,13 @@
 package croundteam.cround.member.domain;
 
 import croundteam.cround.common.domain.BaseTimeEntity;
+import croundteam.cround.member.domain.interest.Interest;
 import lombok.*;
+import org.springframework.beans.factory.annotation.Value;
 
 import javax.persistence.*;
+import java.util.Objects;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -18,18 +22,26 @@ public class Member extends BaseTimeEntity {
     @Column(name = "member_id")
     private Long id;
 
+    @Column(nullable = false, length = 50)
+    private String email;
+
     @Column(nullable = false, length = 20)
     private String username;
 
-    @Column(nullable = false, length = 50)
-    private String email;
+    @Column(nullable = false, length = 20)
+    private String nickname;
 
     @Column(length = 128)
     private String password;
 
+    private String profileImage;
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Role role;
+
+    @Embedded
+    private Interest interest;
 
     @Builder
     public Member(String username, String email, String password) {
@@ -37,6 +49,17 @@ public class Member extends BaseTimeEntity {
         this.email = email;
         this.password = password;
         this.role = Role.USER;
+
+        this.nickname = createUUID();
+        this.profileImage = "https://avatars.githubusercontent.com/u/132455714?s=400&u=b9befff0d433aa7f0eaf9927a4e6f55af3fe9986&v=4";
+    }
+
+    private String createUUID() {
+        return UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
     }
 
     public String getRoleName() {

--- a/src/main/java/croundteam/cround/member/domain/Member.java
+++ b/src/main/java/croundteam/cround/member/domain/Member.java
@@ -4,6 +4,7 @@ import croundteam.cround.common.domain.BaseTimeEntity;
 import croundteam.cround.common.exception.ErrorCode;
 import croundteam.cround.common.exception.member.ProfileImageEmptyException;
 import croundteam.cround.common.exception.member.ProfileImageEqualsException;
+import croundteam.cround.member.domain.follow.Followings;
 import croundteam.cround.member.domain.interest.Interest;
 import lombok.*;
 import org.springframework.beans.factory.annotation.Value;
@@ -31,12 +32,13 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false, length = 20)
     private String username;
 
-    @Column(nullable = false, length = 20)
+    @Column(length = 20)
     private String nickname;
 
-    @Column(length = 128)
+    @Column(nullable = false, length = 128)
     private String password;
 
+    @Column(nullable = false)
     private String profileImage;
 
     @Enumerated(EnumType.STRING)
@@ -45,6 +47,9 @@ public class Member extends BaseTimeEntity {
 
     @Embedded
     private Interest interest;
+
+    @Embedded
+    private Followings followings;
 
     @Builder
     public Member(String username, String email, String password) {

--- a/src/main/java/croundteam/cround/member/domain/follow/Follow.java
+++ b/src/main/java/croundteam/cround/member/domain/follow/Follow.java
@@ -1,0 +1,44 @@
+package croundteam.cround.member.domain.follow;
+
+import croundteam.cround.common.exception.ErrorCode;
+import croundteam.cround.common.exception.member.InvalidSourceTargetFollowException;
+import croundteam.cround.creator.domain.Creator;
+import croundteam.cround.member.domain.Member;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(uniqueConstraints = @UniqueConstraint(
+        name = "follow_source_and_target_composite_unique",
+        columnNames= {"source_id", "target_id"}))
+public class Follow {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_id", foreignKey = @ForeignKey(name = "fk_follow_to_source"))
+    private Member source;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_id", foreignKey = @ForeignKey(name = "fk_follow_to_target"))
+    private Creator target;
+
+    public Follow(Member source, Creator target) {
+        validateSourceAndTarget(source, target);
+        this.source = source;
+        this.target = target;
+    }
+
+    private void validateSourceAndTarget(Member source, Creator target) {
+        Member targetMember = target.getMember();
+
+        if(source.equals(targetMember)) {
+            throw new InvalidSourceTargetFollowException(ErrorCode.INVALID_SOURCE_TARGET_FOLLOW);
+        }
+    }
+}

--- a/src/main/java/croundteam/cround/member/domain/follow/Followers.java
+++ b/src/main/java/croundteam/cround/member/domain/follow/Followers.java
@@ -1,0 +1,21 @@
+package croundteam.cround.member.domain.follow;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import javax.persistence.FetchType;
+import javax.persistence.OneToMany;
+import java.util.List;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Followers {
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "target")
+    private List<Follow> followers;
+
+    public Followers(List<Follow> followers) {
+        this.followers = followers;
+    }
+}

--- a/src/main/java/croundteam/cround/member/domain/follow/Followings.java
+++ b/src/main/java/croundteam/cround/member/domain/follow/Followings.java
@@ -1,0 +1,21 @@
+package croundteam.cround.member.domain.follow;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import javax.persistence.FetchType;
+import javax.persistence.OneToMany;
+import java.util.List;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Followings {
+
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "source")
+    private List<Follow> followings;
+
+    public Followings(List<Follow> followings) {
+        this.followings = followings;
+    }
+}

--- a/src/main/java/croundteam/cround/member/domain/interest/Category.java
+++ b/src/main/java/croundteam/cround/member/domain/interest/Category.java
@@ -1,0 +1,22 @@
+package croundteam.cround.member.domain.interest;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.persistence.Column;
+
+@AllArgsConstructor
+@Getter
+public enum Category {
+    ART("예술"),
+    COOK("요리"),
+    BEAUTY("뷰티"),
+    STUDY("학습"),
+    FASHION("패션"),
+    GAME("게임"),
+    MUSIC("음악"),
+    FINANCE("금융");
+
+    @Column(name = "category_name")
+    private String name;
+}

--- a/src/main/java/croundteam/cround/member/domain/interest/Interest.java
+++ b/src/main/java/croundteam/cround/member/domain/interest/Interest.java
@@ -1,0 +1,24 @@
+package croundteam.cround.member.domain.interest;
+
+import croundteam.cround.creator.domain.platform.PlatformType;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import javax.persistence.Embedded;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Interest {
+
+    @Embedded
+    private PlatformType platformType;
+
+    @Embedded
+    private Category category;
+
+    public Interest(PlatformType platformType, Category category) {
+        this.platformType = platformType;
+        this.category = category;
+    }
+}

--- a/src/test/java/croundteam/cround/creator/domain/CreatorTest.java
+++ b/src/test/java/croundteam/cround/creator/domain/CreatorTest.java
@@ -1,6 +1,7 @@
 package croundteam.cround.creator.domain;
 
 import croundteam.cround.creator.domain.platform.Platform;
+import croundteam.cround.creator.domain.platform.PlatformActivityName;
 import croundteam.cround.creator.domain.platform.PlatformType;
 import croundteam.cround.creator.domain.platform.PlatformUrl;
 import croundteam.cround.creator.repository.CreatorRepository;
@@ -37,7 +38,13 @@ class CreatorTest {
                 .password("password")
                 .email("cround@cround.com")
                 .build();
-        Platform platform = new Platform(new PlatformUrl("cround.com"), new PlatformType("Instagram"));
+
+        Platform platform = new Platform(
+                PlatformUrl.from("cround.com"),
+                PlatformType.from("Instagram"),
+                PlatformActivityName.from("Crounder")
+        );
+
         List<Tag> tagList = Arrays.asList(new Tag("크라운드 대표"), new Tag("크라운드 직원"));
         Tags tags = new Tags(tagList);
 


### PR DESCRIPTION
## 기능 설명
Follow Entity를 생성하고, Member와 Creator의 추가 정보들을 반영한다.

## 기능 상세
- [x] `Member` <-- followings --> `Follow` <-- followers --> `Creator`
- [x] Member => 닉네임, 프로필 이미지, 관심사 필드 추가
- [x] Creator   => private 생성자로 변경 및 정적 팩터리 메서드 추가, 크리에이터 활동명 필드 추가
