### PR TITLE
feat: Follow와 Creator에 정적 팩터리 메서드 및 부가 기능 추가 (#17)

### DIFF
--- a/src/main/java/croundteam/cround/common/advice/ControllerAdvice.java
+++ b/src/main/java/croundteam/cround/common/advice/ControllerAdvice.java
@@ -24,5 +24,11 @@ public class ControllerAdvice {
         return ResponseEntity.status(errorCode.getStatus()).body(new ErrorResponse(errorCode.getMessage()));
     }
 
-
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleException(Exception e) {
+        /**
+         * Slack or Discord 로 Notification 추가
+         */
+        return ResponseEntity.internalServerError().body(new ErrorResponse("알 수 없는 문제가 발생했습니다. 서버 관리자에게 문의주세요."));
+    }
 }

--- a/src/main/java/croundteam/cround/common/exception/ErrorCode.java
+++ b/src/main/java/croundteam/cround/common/exception/ErrorCode.java
@@ -14,6 +14,7 @@ public enum ErrorCode {
     PROFILE_IMAGE_MATCH(HttpStatus.BAD_REQUEST, "설정된 프로필 이미지와 달라야 합니다."),
     PROFILE_IMAGE_EMPTY(HttpStatus.BAD_REQUEST, "입력된 프로필 이미지가 없습니다."),
     INVALID_SOURCE_TARGET_FOLLOW(HttpStatus.BAD_REQUEST, "자기 자신을 팔로우 할 수 없습니다."),
+    INVALID_URI_FORMAT(HttpStatus.BAD_REQUEST, "유효하지 않은 URL 입니다."),
 
     NOT_EXIST_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.");
 

--- a/src/main/java/croundteam/cround/common/exception/member/InvalidUrlFormatException.java
+++ b/src/main/java/croundteam/cround/common/exception/member/InvalidUrlFormatException.java
@@ -1,0 +1,10 @@
+package croundteam.cround.common.exception.member;
+
+import croundteam.cround.common.exception.BusinessException;
+import croundteam.cround.common.exception.ErrorCode;
+
+public class InvalidUrlFormatException extends BusinessException {
+    public InvalidUrlFormatException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/croundteam/cround/creator/domain/platform/Platform.java
+++ b/src/main/java/croundteam/cround/creator/domain/platform/Platform.java
@@ -1,7 +1,6 @@
 package croundteam.cround.creator.domain.platform;
 
 import lombok.AccessLevel;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Embeddable;
@@ -20,9 +19,17 @@ public class Platform {
     @Embedded
     private PlatformActivityName platformActivityName;
 
-    public Platform(PlatformUrl platformUrl, PlatformType platformType, PlatformActivityName platformActivityName) {
+    private Platform(PlatformUrl platformUrl, PlatformType platformType, PlatformActivityName platformActivityName) {
         this.platformUrl = platformUrl;
         this.platformType = platformType;
         this.platformActivityName = platformActivityName;
+    }
+
+    public static Platform of(String platformUrl, String platformType, String platformActivityName) {
+        return new Platform(
+                PlatformUrl.from(platformUrl),
+                PlatformType.from(platformType),
+                PlatformActivityName.from(platformActivityName)
+        );
     }
 }

--- a/src/main/java/croundteam/cround/creator/domain/platform/PlatformType.java
+++ b/src/main/java/croundteam/cround/creator/domain/platform/PlatformType.java
@@ -26,7 +26,6 @@ public class PlatformType {
         return new PlatformType(platformName);
     }
 
-
     public String getPlatformName() {
         return platformName.getName();
     }

--- a/src/main/java/croundteam/cround/creator/domain/platform/PlatformUrl.java
+++ b/src/main/java/croundteam/cround/creator/domain/platform/PlatformUrl.java
@@ -1,11 +1,16 @@
 package croundteam.cround.creator.domain.platform;
 
+import croundteam.cround.common.exception.ErrorCode;
+import croundteam.cround.common.exception.member.InvalidUrlFormatException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
 
 @Embeddable
 @Getter
@@ -16,7 +21,16 @@ public class PlatformUrl {
     private String url;
 
     private PlatformUrl(String url) {
+        validateUrl(url);
         this.url = url;
+    }
+
+    private void validateUrl(String url) {
+        try {
+            new URL(url).toURI();
+        } catch (MalformedURLException | URISyntaxException ex) {
+            throw new InvalidUrlFormatException(ErrorCode.INVALID_URI_FORMAT);
+        }
     }
 
     public static PlatformUrl from(String url) {

--- a/src/main/java/croundteam/cround/member/domain/follow/Follow.java
+++ b/src/main/java/croundteam/cround/member/domain/follow/Follow.java
@@ -1,42 +1,49 @@
 package croundteam.cround.member.domain.follow;
 
+import croundteam.cround.common.domain.BaseTimeEntity;
 import croundteam.cround.common.exception.ErrorCode;
 import croundteam.cround.common.exception.member.InvalidSourceTargetFollowException;
 import croundteam.cround.creator.domain.Creator;
 import croundteam.cround.member.domain.Member;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(uniqueConstraints = @UniqueConstraint(
         name = "follow_source_and_target_composite_unique",
         columnNames= {"source_id", "target_id"}))
-public class Follow {
+public class Follow extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "follow_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "source_id", foreignKey = @ForeignKey(name = "fk_follow_to_source"))
     private Member source;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     @JoinColumn(name = "target_id", foreignKey = @ForeignKey(name = "fk_follow_to_target"))
     private Creator target;
 
-    public Follow(Member source, Creator target) {
+    private Follow(Member source, Creator target) {
         validateSourceAndTarget(source, target);
         this.source = source;
         this.target = target;
     }
 
+    public static Follow of(Member source, Creator target) {
+        return new Follow(source, target);
+    }
+
     private void validateSourceAndTarget(Member source, Creator target) {
         Member targetMember = target.getMember();
-
         if(source.equals(targetMember)) {
             throw new InvalidSourceTargetFollowException(ErrorCode.INVALID_SOURCE_TARGET_FOLLOW);
         }

--- a/src/main/java/croundteam/cround/member/domain/follow/Followers.java
+++ b/src/main/java/croundteam/cround/member/domain/follow/Followers.java
@@ -3,17 +3,19 @@ package croundteam.cround.member.domain.follow;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.FetchType;
 import javax.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Followers {
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "target")
-    private List<Follow> followers;
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "target", cascade = CascadeType.ALL)
+    private List<Follow> followers = new ArrayList<>();
 
     public Followers(List<Follow> followers) {
         this.followers = followers;

--- a/src/main/java/croundteam/cround/member/domain/follow/Followings.java
+++ b/src/main/java/croundteam/cround/member/domain/follow/Followings.java
@@ -1,19 +1,22 @@
 package croundteam.cround.member.domain.follow;
 
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.FetchType;
 import javax.persistence.OneToMany;
+import java.util.ArrayList;
 import java.util.List;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Followings {
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "source")
-    private List<Follow> followings;
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "source", cascade = CascadeType.ALL)
+    private List<Follow> followings = new ArrayList<>();
 
     public Followings(List<Follow> followings) {
         this.followings = followings;

--- a/src/test/java/croundteam/cround/creator/domain/CreatorTest.java
+++ b/src/test/java/croundteam/cround/creator/domain/CreatorTest.java
@@ -39,11 +39,7 @@ class CreatorTest {
                 .email("cround@cround.com")
                 .build();
 
-        Platform platform = new Platform(
-                PlatformUrl.from("cround.com"),
-                PlatformType.from("Instagram"),
-                PlatformActivityName.from("Crounder")
-        );
+        Platform platform = Platform.of("cround.com", "instagram", "crounder");
 
         List<Tag> tagList = Arrays.asList(new Tag("크라운드 대표"), new Tag("크라운드 직원"));
         Tags tags = new Tags(tagList);


### PR DESCRIPTION
## 기능 설명
- Follow와 Creator에 정적 팩터리 메서드 추가
- Follow cascade 옵션 추가
- ExceptionHandler 추가

## 기능 상세
- [x] Follow와 Creator의 이용 편의 및 검증을 위해 매개변수를 가지는 기본 생성자는 private로 변경하고, 정적 팩터리 메서드로 동작되도록 변경
- [x] `Member` <-- Followings ->`Follow` <-- Followers -> `Creator` 간의 관계이므로 상태 변화를 전파를 위해 추가
- [x] Exception 클래스에 대한 핸들러 추가
