### PR TITLE
fix: change field and method name (#29)

### DIFF
--- a/src/main/java/croundteam/cround/tag/domain/Tag.java
+++ b/src/main/java/croundteam/cround/tag/domain/Tag.java
@@ -19,11 +19,11 @@ public class Tag extends BaseTimeEntity {
     @Embedded
     private TagName tagName;
 
-    public Tag(String tagName) {
-        this(TagName.from(tagName));
+    private Tag(TagName tagName) {
+        this.tagName = tagName;
     }
 
-    public Tag(TagName tagName) {
-        this.tagName = tagName;
+    public static Tag of(String tagName) {
+        return new Tag(TagName.from(tagName));
     }
 }

--- a/src/main/java/croundteam/cround/tag/domain/Tag.java
+++ b/src/main/java/croundteam/cround/tag/domain/Tag.java
@@ -23,7 +23,7 @@ public class Tag extends BaseTimeEntity {
         this.tagName = tagName;
     }
 
-    public static Tag of(String tagName) {
-        return new Tag(TagName.from(tagName));
+    public static Tag of(String name) {
+        return new Tag(TagName.from(name));
     }
 }

--- a/src/main/java/croundteam/cround/tag/domain/Tags.java
+++ b/src/main/java/croundteam/cround/tag/domain/Tags.java
@@ -3,6 +3,7 @@ package croundteam.cround.tag.domain;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public class Tags {
@@ -25,14 +26,20 @@ public class Tags {
         return new Tags(tags);
     }
 
-
     public List<Tag> toList() {
         return Collections.unmodifiableList(tags);
     }
 
-    public static List<Tag> toListByNames(String... names) {
-        return Arrays.stream(names)
+    public static Tags toTagsByNames(String... names) {
+        if(Objects.isNull(names)) {
+            /**
+             * TODO: 태그가 0개여도 가능한지 또는 무조건 1개 이상이어야 하는지에 대한 것도 구체화하기
+             * throws new NotEmptyTagException()
+             */
+        }
+        List<Tag> collect = Arrays.stream(names)
                 .map(name -> Tag.of(name))
                 .collect(Collectors.toList());
+        return new Tags(collect);
     }
 }

--- a/src/main/java/croundteam/cround/tag/domain/Tags.java
+++ b/src/main/java/croundteam/cround/tag/domain/Tags.java
@@ -1,17 +1,38 @@
 package croundteam.cround.tag.domain;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class Tags {
 
     private List<Tag> tags;
 
-    public Tags(List<Tag> tags) {
+    private Tags(List<Tag> tags) {
+        validateTags(tags);
         this.tags = tags;
     }
 
+    private void validateTags(List<Tag> tags) {
+        /**
+         * 태그의 개수 제한
+         * 또는 각 태그의 글자 제한을 검증
+         */
+    }
+
+    public static Tags from(List<Tag> tags) {
+        return new Tags(tags);
+    }
+
+
     public List<Tag> toList() {
         return Collections.unmodifiableList(tags);
+    }
+
+    public static List<Tag> toListByNames(String... names) {
+        return Arrays.stream(names)
+                .map(name -> Tag.of(name))
+                .collect(Collectors.toList());
     }
 }

--- a/src/test/java/croundteam/cround/creator/domain/CreatorTest.java
+++ b/src/test/java/croundteam/cround/creator/domain/CreatorTest.java
@@ -35,8 +35,7 @@ class CreatorTest {
                 .build();
 
         Platform platform = Platform.of("cround.com", "instagram", "crounder");
-        List<Tag> tagList = Tags.toListByNames("크라운드 대표", "크라운드 직원");
-        Tags tags = Tags.from(tagList);
+        Tags tags = Tags.toTagsByNames("크라운드 대표", "크라운드 직원");
 
         // when
         Creator creator = new Creator(member, platform, tags);

--- a/src/test/java/croundteam/cround/creator/domain/CreatorTest.java
+++ b/src/test/java/croundteam/cround/creator/domain/CreatorTest.java
@@ -1,14 +1,10 @@
 package croundteam.cround.creator.domain;
 
 import croundteam.cround.creator.domain.platform.Platform;
-import croundteam.cround.creator.domain.platform.PlatformActivityName;
-import croundteam.cround.creator.domain.platform.PlatformType;
-import croundteam.cround.creator.domain.platform.PlatformUrl;
 import croundteam.cround.creator.repository.CreatorRepository;
 import croundteam.cround.member.domain.Member;
 import croundteam.cround.tag.domain.Tag;
 import croundteam.cround.tag.domain.Tags;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,7 +12,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.Commit;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
@@ -40,9 +35,8 @@ class CreatorTest {
                 .build();
 
         Platform platform = Platform.of("cround.com", "instagram", "crounder");
-
-        List<Tag> tagList = Arrays.asList(new Tag("크라운드 대표"), new Tag("크라운드 직원"));
-        Tags tags = new Tags(tagList);
+        List<Tag> tagList = Tags.toListByNames("크라운드 대표", "크라운드 직원");
+        Tags tags = Tags.from(tagList);
 
         // when
         Creator creator = new Creator(member, platform, tags);


### PR DESCRIPTION
## 기능 설명
코드 리뷰 내용으로 받은 가변 인자 메서드의 디테일과 메서드, 변수 네이밍을 명확하게 변경

## 기능 상세
- [x] 가변 인자 메서드에 Null 체크 로직 추가했지만 디테일한 태그 정책이 정해지지 않아 별도 예외를 던지지 않음
- [x] 기존 가변 인자 메서드의 반환 타입으로 `List<Tag>`를 해주던 것을 `Tags`로 변경하여 List<Tag> to Tags로 변환(covert)하는 로직을 간소화함
- [x] Embedded 타입의 이름과 매개변수의 이름을 구분짓도록 변경함
