### PR TITLE
feat: Creator Validation 및 팔로우/언팔로우 기능 추가 (#47, #48)

### DIFF
--- a/api/http/Member.http
+++ b/api/http/Member.http
@@ -11,6 +11,19 @@ Content-Type: application/json
   "interestPlatform": ["YOUTUBE", "TIKTOK"]
 }
 
+### 회원가입
+POST localhost:8080/api/members
+Content-Type: application/json
+
+{
+  "email": "cround1@cround.com",
+  "username": "크라운드",
+  "nickname": "크라운드1",
+  "password": "cround",
+  "confirmPassword": "cround",
+  "interestPlatform": ["YOUTUBE", "TIKTOK"]
+}
+
 ### 일반 로그인
 POST localhost:8080/auth/login
 Content-Type: application/json
@@ -18,6 +31,24 @@ Content-Type: application/json
 {
   "email": "cround@cround.com",
   "password": "cround"
+}
+
+### 팔로우
+POST localhost:8080/api/members/following
+Content-Type: application/json
+
+{
+  "sourceId": 2,
+  "targetId": 1
+}
+
+### 언팔로우
+DELETE localhost:8080/api/members/following
+Content-Type: application/json
+
+{
+  "sourceId": 2,
+  "targetId": 1
 }
 
 ### 소셜 로그인

--- a/src/main/java/croundteam/cround/common/exception/ErrorCode.java
+++ b/src/main/java/croundteam/cround/common/exception/ErrorCode.java
@@ -13,6 +13,7 @@ public enum ErrorCode {
     DUPLICATE_PLATFORM_ACTIVITY_NAME(HttpStatus.BAD_REQUEST, "이미 존재하는 활동명입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     INVALID_PLATFORM_NAME(HttpStatus.BAD_REQUEST, "존재하지 않는 플랫폼 유형입니다."),
+    INVALID_FOLLOW(HttpStatus.BAD_REQUEST, "팔로우 정보가 존재하지 않습니다."),
     PROFILE_IMAGE_MATCH(HttpStatus.BAD_REQUEST, "설정된 프로필 이미지와 달라야 합니다."),
     PROFILE_IMAGE_EMPTY(HttpStatus.BAD_REQUEST, "입력된 프로필 이미지가 없습니다."),
     INVALID_SOURCE_TARGET_FOLLOW(HttpStatus.BAD_REQUEST, "자기 자신을 팔로우 할 수 없습니다."),
@@ -21,7 +22,9 @@ public enum ErrorCode {
     EXCEED_TAGS_MAX_SIZE(HttpStatus.BAD_REQUEST, "태그는 최대 7개까지 설정할 수 있습니다."),
     EXCEED_TAG_LENGTH(HttpStatus.BAD_REQUEST, "태그는 최대 20글자까지 입력할 수 있습니다."),
 
+    NOT_EXIST_CREATOR(HttpStatus.NOT_FOUND, "존재하지 않는 크리에이터입니다."),
     NOT_EXIST_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다.");
+
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/croundteam/cround/common/exception/ErrorCode.java
+++ b/src/main/java/croundteam/cround/common/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
 
     DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 존재하는 E-mail입니다."),
     DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 존재하는 닉네임입니다."),
+    DUPLICATE_PLATFORM_ACTIVITY_NAME(HttpStatus.BAD_REQUEST, "이미 존재하는 활동명입니다."),
     PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     INVALID_PLATFORM_NAME(HttpStatus.BAD_REQUEST, "존재하지 않는 플랫폼 유형입니다."),
     PROFILE_IMAGE_MATCH(HttpStatus.BAD_REQUEST, "설정된 프로필 이미지와 달라야 합니다."),

--- a/src/main/java/croundteam/cround/common/exception/member/DuplicateCreatorPlatformActivityNameException.java
+++ b/src/main/java/croundteam/cround/common/exception/member/DuplicateCreatorPlatformActivityNameException.java
@@ -1,0 +1,10 @@
+package croundteam.cround.common.exception.member;
+
+import croundteam.cround.common.exception.BusinessException;
+import croundteam.cround.common.exception.ErrorCode;
+
+public class DuplicateCreatorPlatformActivityNameException extends BusinessException {
+    public DuplicateCreatorPlatformActivityNameException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/croundteam/cround/common/exception/member/InvalidFollowException.java
+++ b/src/main/java/croundteam/cround/common/exception/member/InvalidFollowException.java
@@ -1,0 +1,10 @@
+package croundteam.cround.common.exception.member;
+
+import croundteam.cround.common.exception.BusinessException;
+import croundteam.cround.common.exception.ErrorCode;
+
+public class InvalidFollowException extends BusinessException {
+    public InvalidFollowException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/croundteam/cround/common/exception/member/NotExistCreatorException.java
+++ b/src/main/java/croundteam/cround/common/exception/member/NotExistCreatorException.java
@@ -1,0 +1,10 @@
+package croundteam.cround.common.exception.member;
+
+import croundteam.cround.common.exception.BusinessException;
+import croundteam.cround.common.exception.ErrorCode;
+
+public class NotExistCreatorException extends BusinessException {
+    public NotExistCreatorException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/croundteam/cround/creator/domain/Creator.java
+++ b/src/main/java/croundteam/cround/creator/domain/Creator.java
@@ -36,7 +36,7 @@ public class Creator extends BaseTimeEntity {
     @Embedded
     private Platform platform;
 
-    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "member_id", foreignKey = @ForeignKey(name = "fk_creator_to_member"))
     private Member member;
 
@@ -54,8 +54,10 @@ public class Creator extends BaseTimeEntity {
         this.creatorTags = castTagsToCreatorTags(creatorTags);
     }
 
-    public void addMember(Member member) {
-        this.member = member;
+    private List<CreatorTag> castTagsToCreatorTags(Tags tags) {
+        return tags.toList().stream()
+                .map(tag -> CreatorTag.of(this, tag))
+                .collect(Collectors.toList());
     }
 
     public static Creator of(String profileImage, Member member, Platform platform, Tags creatorTags) {
@@ -67,21 +69,23 @@ public class Creator extends BaseTimeEntity {
                 .build();
     }
 
-    public void addFollowers(Follow follow) {
-        getFollowers().add(follow);
+    public void addMember(Member member) {
+        this.member = member;
+    }
+
+    public void add(Follow follow) {
+        followers.add(follow);
+    }
+
+    public void remove(Follow follow) {
+        followers.remove(follow);
     }
 
     public String getActivityName() {
         return platform.getPlatformActivityName();
     }
 
-    public List<Follow> getFollowers() {
-        return followers.getFollowers();
-    }
-
-    private List<CreatorTag> castTagsToCreatorTags(Tags tags) {
-        return tags.toList().stream()
-                .map(tag -> CreatorTag.of(this, tag))
-                .collect(Collectors.toList());
+    public Long getMemberId() {
+        return member.getId();
     }
 }

--- a/src/main/java/croundteam/cround/creator/domain/platform/PlatformActivityName.java
+++ b/src/main/java/croundteam/cround/creator/domain/platform/PlatformActivityName.java
@@ -1,5 +1,6 @@
 package croundteam.cround.creator.domain.platform;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -12,7 +13,7 @@ import javax.persistence.Embeddable;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PlatformActivityName {
 
-    @Column(name = "activity_name")
+    @Column(name = "platform_activity_name")
     private String name;
 
     private PlatformActivityName(String name) {

--- a/src/main/java/croundteam/cround/creator/domain/tag/CreatorTag.java
+++ b/src/main/java/croundteam/cround/creator/domain/tag/CreatorTag.java
@@ -26,7 +26,7 @@ public class CreatorTag {
     @JoinColumn(name = "tag_id", foreignKey = @ForeignKey(name = "fk_creatortag_to_tag"))
     private Tag tag;
 
-    public CreatorTag(Creator creator, Tag tag) {
+    private CreatorTag(Creator creator, Tag tag) {
         this.creator = creator;
         this.tag = tag;
     }

--- a/src/main/java/croundteam/cround/creator/repository/CreatorRepository.java
+++ b/src/main/java/croundteam/cround/creator/repository/CreatorRepository.java
@@ -4,4 +4,5 @@ import croundteam.cround.creator.domain.Creator;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CreatorRepository extends JpaRepository<Creator, Long> {
+    boolean existByPlatformActivityName(String platformActivityName);
 }

--- a/src/main/java/croundteam/cround/creator/repository/CreatorRepository.java
+++ b/src/main/java/croundteam/cround/creator/repository/CreatorRepository.java
@@ -4,5 +4,6 @@ import croundteam.cround.creator.domain.Creator;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CreatorRepository extends JpaRepository<Creator, Long> {
-    boolean existByPlatformActivityName(String platformActivityName);
+
+    boolean existsByPlatformPlatformActivityNameName(String platformActivityName);
 }

--- a/src/main/java/croundteam/cround/creator/service/CreatorService.java
+++ b/src/main/java/croundteam/cround/creator/service/CreatorService.java
@@ -2,7 +2,6 @@ package croundteam.cround.creator.service;
 
 import croundteam.cround.common.exception.ErrorCode;
 import croundteam.cround.common.exception.member.DuplicateCreatorPlatformActivityNameException;
-import croundteam.cround.common.exception.member.DuplicateEmailException;
 import croundteam.cround.common.exception.member.NotExistMemberException;
 import croundteam.cround.creator.domain.Creator;
 import croundteam.cround.creator.dto.CreatorSaveRequest;
@@ -36,7 +35,7 @@ public class CreatorService {
     }
 
     private void validateCreator(CreatorSaveRequest creatorSaveRequest) {
-        if(creatorRepository.existByPlatformActivityName(creatorSaveRequest.getPlatformActivityName())) {
+        if(creatorRepository.existsByPlatformPlatformActivityNameName(creatorSaveRequest.getPlatformActivityName())) {
             throw new DuplicateCreatorPlatformActivityNameException(ErrorCode.DUPLICATE_PLATFORM_ACTIVITY_NAME);
         }
     }

--- a/src/main/java/croundteam/cround/creator/service/CreatorService.java
+++ b/src/main/java/croundteam/cround/creator/service/CreatorService.java
@@ -1,6 +1,8 @@
 package croundteam.cround.creator.service;
 
 import croundteam.cround.common.exception.ErrorCode;
+import croundteam.cround.common.exception.member.DuplicateCreatorPlatformActivityNameException;
+import croundteam.cround.common.exception.member.DuplicateEmailException;
 import croundteam.cround.common.exception.member.NotExistMemberException;
 import croundteam.cround.creator.domain.Creator;
 import croundteam.cround.creator.dto.CreatorSaveRequest;
@@ -22,6 +24,8 @@ public class CreatorService {
     private final CreatorRepository creatorRepository;
 
     public String createCreator(Long memberId, CreatorSaveRequest creatorSaveRequest) {
+        validateCreator(creatorSaveRequest);
+
         Member member = findMemberById(memberId);
         Creator creator = creatorSaveRequest.toEntity();
         creator.addMember(member);
@@ -29,6 +33,12 @@ public class CreatorService {
         Creator saveCreator = creatorRepository.save(creator);
 
         return saveCreator.getActivityName();
+    }
+
+    private void validateCreator(CreatorSaveRequest creatorSaveRequest) {
+        if(creatorRepository.existByPlatformActivityName(creatorSaveRequest.getPlatformActivityName())) {
+            throw new DuplicateCreatorPlatformActivityNameException(ErrorCode.DUPLICATE_PLATFORM_ACTIVITY_NAME);
+        }
     }
 
     private Member findMemberById(Long memberId) {

--- a/src/main/java/croundteam/cround/member/controller/MemberController.java
+++ b/src/main/java/croundteam/cround/member/controller/MemberController.java
@@ -1,14 +1,9 @@
 package croundteam.cround.member.controller;
 
-import croundteam.cround.member.dto.EmailValidationRequest;
-import croundteam.cround.member.dto.MemberSaveRequest;
-import croundteam.cround.member.dto.NicknameValidationRequest;
+import croundteam.cround.member.dto.*;
 import croundteam.cround.member.service.MemberService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.net.URI;
@@ -40,6 +35,19 @@ public class MemberController {
         memberService.validateDuplicateNickname(nicknameValidationRequest.getNickname());
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/following")
+    public ResponseEntity<FollowResponse> followCreator(@RequestBody FollowRequest followRequest) {
+        FollowResponse followResponse = memberService.followCreator(followRequest);
+        return ResponseEntity.ok(followResponse);
+    }
+
+    @DeleteMapping("/following")
+    public ResponseEntity<FollowResponse> unfollowCreator(@RequestBody FollowRequest followRequest) {
+        FollowResponse followResponse = memberService.unfollowCreator(followRequest);
+        return ResponseEntity.ok(followResponse);
+    }
+
 
     /**
      * /me/password

--- a/src/main/java/croundteam/cround/member/domain/Member.java
+++ b/src/main/java/croundteam/cround/member/domain/Member.java
@@ -1,17 +1,13 @@
 package croundteam.cround.member.domain;
 
 import croundteam.cround.common.domain.BaseTimeEntity;
-import croundteam.cround.common.exception.ErrorCode;
-import croundteam.cround.common.exception.member.ProfileImageEmptyException;
-import croundteam.cround.common.exception.member.ProfileImageEqualsException;
+import croundteam.cround.creator.domain.Creator;
+import croundteam.cround.member.domain.follow.Follow;
 import croundteam.cround.member.domain.follow.Followings;
 import croundteam.cround.member.domain.interest.Interest;
 import lombok.*;
-import org.springframework.beans.factory.annotation.Value;
 
 import javax.persistence.*;
-import java.util.Objects;
-import java.util.UUID;
 
 @Entity
 @Getter
@@ -58,12 +54,24 @@ public class Member extends BaseTimeEntity {
         this.role = Role.USER;
     }
 
-    public String getRoleName() {
-        return role.getName();
-    }
-
     public void update(Member member) {
         this.email = member.getEmail();
         this.username = member.getUsername();
+    }
+
+    public void follow(Creator target) {
+        Follow follow = Follow.of(this, target);
+        followings.add(follow);
+        target.add(follow);
+    }
+
+    public void unfollow(Creator target) {
+        Follow follow = Follow.of(this, target);
+        followings.remove(follow);
+        target.remove(follow);
+    }
+
+    public String getRoleName() {
+        return role.getName();
     }
 }

--- a/src/main/java/croundteam/cround/member/domain/follow/Follow.java
+++ b/src/main/java/croundteam/cround/member/domain/follow/Follow.java
@@ -5,9 +5,7 @@ import croundteam.cround.common.exception.ErrorCode;
 import croundteam.cround.common.exception.member.InvalidSourceTargetFollowException;
 import croundteam.cround.creator.domain.Creator;
 import croundteam.cround.member.domain.Member;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import javax.persistence.*;
 
@@ -17,6 +15,8 @@ import javax.persistence.*;
 @Table(uniqueConstraints = @UniqueConstraint(
         name = "follow_source_and_target_composite_unique",
         columnNames= {"source_id", "target_id"}))
+@ToString
+@EqualsAndHashCode(of = {"source", "target"})
 public class Follow extends BaseTimeEntity {
 
     @Id
@@ -24,11 +24,11 @@ public class Follow extends BaseTimeEntity {
     @Column(name = "follow_id")
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "source_id", foreignKey = @ForeignKey(name = "fk_follow_to_source"))
     private Member source;
 
-    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "target_id", foreignKey = @ForeignKey(name = "fk_follow_to_target"))
     private Creator target;
 
@@ -43,8 +43,7 @@ public class Follow extends BaseTimeEntity {
     }
 
     private void validateSourceAndTarget(Member source, Creator target) {
-        Member targetMember = target.getMember();
-        if(source.equals(targetMember)) {
+        if(source.getId().equals(target.getMemberId())) {
             throw new InvalidSourceTargetFollowException(ErrorCode.INVALID_SOURCE_TARGET_FOLLOW);
         }
     }

--- a/src/main/java/croundteam/cround/member/domain/follow/Followers.java
+++ b/src/main/java/croundteam/cround/member/domain/follow/Followers.java
@@ -1,5 +1,7 @@
 package croundteam.cround.member.domain.follow;
 
+import croundteam.cround.common.exception.ErrorCode;
+import croundteam.cround.common.exception.member.InvalidFollowException;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,13 +15,23 @@ import java.util.List;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Getter
 public class Followers {
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "target", cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "target", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<Follow> followers = new ArrayList<>();
 
-    public Followers(List<Follow> followers) {
-        this.followers = followers;
+    public void add(Follow follow) {
+        followers.add(follow);
+    }
+
+    public void remove(Follow follow) {
+        validateFollow(follow);
+        followers.remove(follow);
+    }
+
+    private void validateFollow(Follow follow) {
+        if(!followers.contains(follow)) {
+            throw new InvalidFollowException(ErrorCode.INVALID_FOLLOW);
+        }
     }
 }

--- a/src/main/java/croundteam/cround/member/domain/follow/Followings.java
+++ b/src/main/java/croundteam/cround/member/domain/follow/Followings.java
@@ -1,7 +1,8 @@
 package croundteam.cround.member.domain.follow;
 
+import croundteam.cround.common.exception.ErrorCode;
+import croundteam.cround.common.exception.member.InvalidFollowException;
 import lombok.AccessLevel;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.CascadeType;
@@ -15,10 +16,21 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Followings {
 
-    @OneToMany(fetch = FetchType.LAZY, mappedBy = "source", cascade = CascadeType.ALL)
+    @OneToMany(fetch = FetchType.LAZY, mappedBy = "source", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<Follow> followings = new ArrayList<>();
 
-    public Followings(List<Follow> followings) {
-        this.followings = followings;
+    public void add(Follow follow) {
+        followings.add(follow);
+    }
+
+    public void remove(Follow follow) {
+        validateFollow(follow);
+        followings.remove(follow);
+    }
+
+    private void validateFollow(Follow follow) {
+        if(!followings.contains(follow)) {
+            throw new InvalidFollowException(ErrorCode.INVALID_FOLLOW);
+        }
     }
 }

--- a/src/main/java/croundteam/cround/member/dto/FollowRequest.java
+++ b/src/main/java/croundteam/cround/member/dto/FollowRequest.java
@@ -1,0 +1,13 @@
+package croundteam.cround.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowRequest {
+    private Long sourceId;
+    private Long targetId;
+}

--- a/src/main/java/croundteam/cround/member/dto/FollowResponse.java
+++ b/src/main/java/croundteam/cround/member/dto/FollowResponse.java
@@ -1,0 +1,15 @@
+package croundteam.cround.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowResponse {
+
+    private Long sourceId;
+    private Long targetId;
+
+}

--- a/src/main/java/croundteam/cround/tag/domain/Tag.java
+++ b/src/main/java/croundteam/cround/tag/domain/Tag.java
@@ -12,7 +12,6 @@ import javax.persistence.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@ToString
 public class Tag extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/croundteam/cround/tag/domain/Tags.java
+++ b/src/main/java/croundteam/cround/tag/domain/Tags.java
@@ -15,14 +15,30 @@ public class Tags {
     private List<Tag> tags;
 
     private Tags(List<Tag> tags) {
-        validateTags(tags);
-        this.tags = tags;
-    }
-
-    private void validateTags(List<Tag> tags) {
         validateTagsSize(tags);
         validateTagLength(tags);
         this.tags = tags;
+    }
+
+    public static Tags from(List<Tag> tags) {
+        return new Tags(tags);
+    }
+
+    public List<Tag> toList() {
+        return Collections.unmodifiableList(tags);
+    }
+
+    public static Tags toTagsByNames(String... names) {
+        if(Objects.isNull(names)) {
+            /**
+             * TODO: 태그가 0개여도 가능한지 또는 무조건 1개 이상이어야 하는지에 대한 것도 구체화하기
+             * throws new NotEmptyTagException()
+             */
+        }
+        List<Tag> collect = Arrays.stream(names)
+                .map(name -> Tag.from(name))
+                .collect(Collectors.toList());
+        return new Tags(collect);
     }
 
     private void validateTagLength(List<Tag> tags) {
@@ -37,34 +53,5 @@ public class Tags {
         if(tags.size() > CREATOR_TAGS_MAX_SIZE) {
             throw new ExceedTagsSizeException(ErrorCode.EXCEED_TAGS_MAX_SIZE);
         }
-    }
-
-    public static Tags from(List<Tag> tags) {
-        return new Tags(tags);
-    }
-
-//    public static Tags from(List<String> tags) {
-//        return new Tags(castTagsList(tags));
-//    }
-
-    public List<Tag> toList() {
-        return Collections.unmodifiableList(tags);
-    }
-
-    public static List<Tag> castTagsList(List<String> tagNames) {
-        return tagNames.stream().map(Tag::from).collect(Collectors.toList());
-    }
-
-    public static Tags toTagsByNames(String... names) {
-        if(Objects.isNull(names)) {
-            /**
-             * TODO: 태그가 0개여도 가능한지 또는 무조건 1개 이상이어야 하는지에 대한 것도 구체화하기
-             * throws new NotEmptyTagException()
-             */
-        }
-        List<Tag> collect = Arrays.stream(names)
-                .map(name -> Tag.from(name))
-                .collect(Collectors.toList());
-        return new Tags(collect);
     }
 }


### PR DESCRIPTION
## 기능 설명
- 크리에이터로 등록할때 존재하는 크리에이터 이름이 있는지 확인하는 검증 로직 추가
- `회원` <-- 팔로워 - `팔로우` --팔로잉 --> `크리에이터` 의 구성에 맞게 팔로우/언팔로우 API 추가
- 미사용 메서드 및 로직 삭제

## 기능 상세
- [x] 크리에이터로 등록할때 존재하는 크리에이터 이름이 있는지 확인하는 검증 로직 추가
- [x] `회원` <-- 팔로워 - `팔로우` --팔로잉 --> `크리에이터` 의 구성에 맞게 팔로우/언팔로우 API 추가

## 트러블슈팅
- 언팔로우시 cascade가 ALL로 설정되어 있어서 회원, 크리에이터, 태그 등이 전부 삭제되는 문제가 존재했으나 PERSIST로 변경하여 해결
- Follow의 equals와 hashcode가 클래스내 모든 필드들로 잡혀있어서 동등성 검사에 실패하는 문제가 있었으나 source와 target만을 재정의하여 해결