### PR TITLE
feat: secure cookie에 refresh 토큰을 추가하고, 응답에 access 토큰만 내려준다 (#36)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,7 @@ out/
 ### VS Code ###
 .vscode/
 
-/src/main/resources/application-jwt.yml
+/src/main/resources/application-security-common.yml
 /src/main/resources/application-oauth.yml
 /src/main/resources/application-aws.yml
 /api/http/**

--- a/src/main/java/croundteam/cround/member/controller/AuthController.java
+++ b/src/main/java/croundteam/cround/member/controller/AuthController.java
@@ -2,6 +2,7 @@ package croundteam.cround.member.controller;
 
 import croundteam.cround.common.dto.TokenResponse;
 import croundteam.cround.member.service.AuthService;
+import croundteam.cround.member.service.dto.LoginResponse;
 import croundteam.cround.member.service.dto.MemberLoginRequest;
 import croundteam.cround.security.CookieUtils;
 import lombok.RequiredArgsConstructor;
@@ -21,18 +22,24 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/auth/login")
-    public ResponseEntity<TokenResponse> login(@RequestBody @Valid final MemberLoginRequest memberLoginRequest) {
+    public ResponseEntity<LoginResponse> login(@RequestBody @Valid final MemberLoginRequest memberLoginRequest) {
         TokenResponse tokenResponse = authService.login(memberLoginRequest);
-        ResponseCookie responseCookie = CookieUtils.create(tokenResponse.getRefreshToken());
+        ResponseCookie responseCookie = CookieUtils.create(tokenResponse.excludeBearerInRefreshToken());
 
-        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, responseCookie.toString()).body(tokenResponse);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                .body(LoginResponse.create(tokenResponse.getAccessToken()));
     }
 
     @GetMapping("/auth/{provider}/login")
-    public ResponseEntity<TokenResponse> loginByOAuth(@PathVariable String provider, @RequestParam String code) {
+    public ResponseEntity<LoginResponse> loginByOAuth(
+            @PathVariable final String provider,
+            @RequestParam final String code) {
         TokenResponse tokenResponse = authService.loginByOAuth(provider, code);
-        ResponseCookie responseCookie = CookieUtils.create(tokenResponse.getRefreshToken());
+        ResponseCookie responseCookie = CookieUtils.create(tokenResponse.excludeBearerInRefreshToken());
 
-        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, responseCookie.toString()).body(tokenResponse);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+                .body(LoginResponse.create(tokenResponse.getAccessToken()));
     }
 }

--- a/src/main/java/croundteam/cround/member/controller/AuthController.java
+++ b/src/main/java/croundteam/cround/member/controller/AuthController.java
@@ -3,8 +3,11 @@ package croundteam.cround.member.controller;
 import croundteam.cround.common.dto.TokenResponse;
 import croundteam.cround.member.service.AuthService;
 import croundteam.cround.member.service.dto.MemberLoginRequest;
+import croundteam.cround.security.CookieUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -20,12 +23,16 @@ public class AuthController {
     @PostMapping("/auth/login")
     public ResponseEntity<TokenResponse> login(@RequestBody @Valid final MemberLoginRequest memberLoginRequest) {
         TokenResponse tokenResponse = authService.login(memberLoginRequest);
-        return ResponseEntity.ok().body(tokenResponse);
+        ResponseCookie responseCookie = CookieUtils.create(tokenResponse.getRefreshToken());
+
+        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, responseCookie.toString()).body(tokenResponse);
     }
 
     @GetMapping("/auth/{provider}/login")
     public ResponseEntity<TokenResponse> loginByOAuth(@PathVariable String provider, @RequestParam String code) {
         TokenResponse tokenResponse = authService.loginByOAuth(provider, code);
-        return ResponseEntity.ok().body(tokenResponse);
+        ResponseCookie responseCookie = CookieUtils.create(tokenResponse.getRefreshToken());
+
+        return ResponseEntity.ok().header(HttpHeaders.SET_COOKIE, responseCookie.toString()).body(tokenResponse);
     }
 }

--- a/src/main/java/croundteam/cround/member/service/dto/LoginResponse.java
+++ b/src/main/java/croundteam/cround/member/service/dto/LoginResponse.java
@@ -1,0 +1,17 @@
+package croundteam.cround.member.service.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class LoginResponse {
+
+    private String accessToken;
+
+    public static LoginResponse create(String token) {
+        return new LoginResponse(token);
+    }
+}

--- a/src/main/java/croundteam/cround/security/CookieUtils.java
+++ b/src/main/java/croundteam/cround/security/CookieUtils.java
@@ -1,19 +1,25 @@
 package croundteam.cround.security;
 
-import org.springframework.http.HttpHeaders;
+import croundteam.cround.security.token.support.JwtTokenExtractor;
+import org.springframework.boot.web.server.Cookie;
 import org.springframework.http.ResponseCookie;
 
 public class CookieUtils {
 
     private static final String COOKIE_NAME = "refreshToken";
-    private static final String COOKIE_NAME = "refreshToken";
+    private static final int REFRESH_TOKEN_EXPIRE_AGE = 7 * 24 * 60 * 60;
 
     private CookieUtils() {}
 
-    public static void create(String refreshToken) {
-        return ResponseCookie.from(COOKIE_NAME, refreshToken)
+    public static ResponseCookie create(String refreshToken) {
+        String token = JwtTokenExtractor.extract(refreshToken);
+
+        return ResponseCookie.from(COOKIE_NAME, token)
                 .httpOnly(true)
                 .path("/")
-                .maxAge()
+                .maxAge(REFRESH_TOKEN_EXPIRE_AGE)
+                .secure(true)
+                .sameSite(Cookie.SameSite.NONE.attributeValue())
+                .build();
     }
 }

--- a/src/main/java/croundteam/cround/security/CookieUtils.java
+++ b/src/main/java/croundteam/cround/security/CookieUtils.java
@@ -1,0 +1,19 @@
+package croundteam.cround.security;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+
+public class CookieUtils {
+
+    private static final String COOKIE_NAME = "refreshToken";
+    private static final String COOKIE_NAME = "refreshToken";
+
+    private CookieUtils() {}
+
+    public static void create(String refreshToken) {
+        return ResponseCookie.from(COOKIE_NAME, refreshToken)
+                .httpOnly(true)
+                .path("/")
+                .maxAge()
+    }
+}

--- a/src/main/java/croundteam/cround/security/CookieUtils.java
+++ b/src/main/java/croundteam/cround/security/CookieUtils.java
@@ -12,9 +12,7 @@ public class CookieUtils {
     private CookieUtils() {}
 
     public static ResponseCookie create(String refreshToken) {
-        String token = JwtTokenExtractor.extract(refreshToken);
-
-        return ResponseCookie.from(COOKIE_NAME, token)
+        return ResponseCookie.from(COOKIE_NAME, refreshToken)
                 .httpOnly(true)
                 .path("/")
                 .maxAge(REFRESH_TOKEN_EXPIRE_AGE)

--- a/src/main/java/croundteam/cround/security/HealthController.java
+++ b/src/main/java/croundteam/cround/security/HealthController.java
@@ -18,13 +18,6 @@ public class HealthController {
         return map;
     }
 
-    @GetMapping("/cround/login")
-    public Map<String, String> loginPage() {
-        Map<String, String> map = new HashMap<>();
-        map.put("message", "로그인을 해주는 페이지로 이동시켜야 한다.");
-        return map;
-    }
-
     @GetMapping("/cround/auth")
     public Map<String, String> auth() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();

--- a/src/main/java/croundteam/cround/security/token/AuthenticationHandlerMethodArgumentResolver.java
+++ b/src/main/java/croundteam/cround/security/token/AuthenticationHandlerMethodArgumentResolver.java
@@ -12,6 +12,8 @@ import org.springframework.web.method.support.ModelAndViewContainer;
 
 import javax.servlet.http.HttpServletRequest;
 
+import static croundteam.cround.security.token.support.TokenProvider.AUTHORIZATION;
+
 public class AuthenticationHandlerMethodArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final TokenProvider tokenProvider;
@@ -33,7 +35,9 @@ public class AuthenticationHandlerMethodArgumentResolver implements HandlerMetho
             WebDataBinderFactory binderFactory
     ) throws Exception {
         HttpServletRequest request = webRequest.getNativeRequest(HttpServletRequest.class);
-        String token = JwtTokenExtractor.extract(request);
+        String authorization = request.getHeader(AUTHORIZATION);
+        String token = JwtTokenExtractor.extract(authorization);
+
         String email = tokenProvider.getUserEmailFromToken(token);
 
         return new LoginMember(email);

--- a/src/main/java/croundteam/cround/security/token/support/JwtTokenExtractor.java
+++ b/src/main/java/croundteam/cround/security/token/support/JwtTokenExtractor.java
@@ -3,16 +3,13 @@ package croundteam.cround.security.token.support;
 import croundteam.cround.common.exception.ErrorCode;
 import croundteam.cround.common.exception.security.InvalidBearerTokenException;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.Objects;
 
-import static croundteam.cround.security.token.support.TokenProvider.AUTHORIZATION;
 import static croundteam.cround.security.token.support.TokenProvider.BEARER;
 
 public class JwtTokenExtractor {
 
-    public static String extract(HttpServletRequest request) {
-        String token = request.getHeader(AUTHORIZATION);
+    public static String extract(String token) {
         validateBearerToken(token);
         return token.substring(BEARER.length());
     }

--- a/src/main/java/croundteam/cround/security/token/support/TokenProvider.java
+++ b/src/main/java/croundteam/cround/security/token/support/TokenProvider.java
@@ -25,7 +25,7 @@ public class TokenProvider {
     public static final long ACCESS_TOKEN_EXPIRE = 2 * 60 * 60 * 1000L;      //    2 Hour
     public static final long REFRESH_TOKEN_EXPIRE = 7 * 24 * 60 * 60 * 1000L; // 168 Hour
 
-    @Value("${jwt.secret}")
+    @Value("${security.jwt.secret}")
     private String secretKey;
     private Key key;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,4 +7,4 @@ spring:
         - localport
       prod:
         - aws
-    include: jwt, oauth
+    include: security-common, oauth


### PR DESCRIPTION
## 기능 설명
secure cookie에 refresh 토큰을 추가하고, 응답에 access 토큰만 내려준다 (#36)

## 기능 상세
- [x] application-jwt.yml -> application-security-common.yml 파일명 변경
- [x] CookieUtils를 만들고 secure cookie에 RTK 을 담는다.
- [x] 응답을 TokenResponse -> LoginResponse로 변경하고, ATK만 값을 전달한다.
