### PR TITLE
feat: 크리에이터 검색 API 추가 (#71)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build/
 bin/
 !**/src/main/**/bin/
 !**/src/test/**/bin/
+src/main/generated/**
 
 ### IntelliJ IDEA ###
 .idea

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+	implementation 'com.querydsl:querydsl-jpa'
+	implementation 'com.querydsl:querydsl-apt'
 
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
@@ -49,6 +51,28 @@ dependencies {
 	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
+def querydslSrcDir = 'src/main/generated'
+sourceSets {
+	main {
+		java {
+			srcDirs += [ querydslSrcDir ]
+		}
+	}
+}
+
+compileJava {
+	options.compilerArgs << '-Aquerydsl.generatedAnnotationClass=javax.annotation.Generated'
+}
+
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+tasks.withType(JavaCompile) {
+	options.generatedSourceOutputDirectory = file(querydslSrcDir)
+}
+
+clean {
+	// clean 실행 시 생성된 QClass 삭제
+	delete file(querydslSrcDir)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,16 +25,28 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
-	compileOnly 'org.projectlombok:lombok'
+
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+
 	annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
-	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+	annotationProcessor(
+			"com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jpa",
+			"jakarta.persistence:jakarta.persistence-api",
+			"jakarta.annotation:jakarta.annotation-api",
+	)
+
+	compileOnly 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/src/main/java/croundteam/cround/board/domain/Board.java
+++ b/src/main/java/croundteam/cround/board/domain/Board.java
@@ -3,6 +3,7 @@ package croundteam.cround.board.domain;
 import croundteam.cround.board.exception.InvalidBookmarkException;
 import croundteam.cround.board.exception.InvalidLikeException;
 import croundteam.cround.board.service.dto.BoardSaveRequest;
+import croundteam.cround.common.domain.BaseTime;
 import croundteam.cround.common.exception.ErrorCode;
 import croundteam.cround.creator.domain.Creator;
 import croundteam.cround.creator.domain.platform.PlatformType;
@@ -20,7 +21,7 @@ import java.util.List;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "board")
-public class Board {
+public class Board extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/croundteam/cround/common/domain/BaseTime.java
+++ b/src/main/java/croundteam/cround/common/domain/BaseTime.java
@@ -11,7 +11,7 @@ import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 
 @Getter
-@EntityListeners(value = {AuditingEntityListener.class})
+@EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
 public abstract class BaseTime {
 

--- a/src/main/java/croundteam/cround/common/exception/ErrorCode.java
+++ b/src/main/java/croundteam/cround/common/exception/ErrorCode.java
@@ -19,7 +19,7 @@ public enum ErrorCode {
     PROFILE_IMAGE_MATCH(HttpStatus.BAD_REQUEST, "설정된 프로필 이미지와 달라야 합니다."),
     PROFILE_IMAGE_EMPTY(HttpStatus.BAD_REQUEST, "입력된 프로필 이미지가 없습니다."),
 
-    EXCEED_TAGS_MAX_SIZE(HttpStatus.BAD_REQUEST, "태그는 최대 7개까지 설정할 수 있습니다."),
+    EXCEED_TAGS_SIZE(HttpStatus.BAD_REQUEST, "태그는 최소 1개, 최대 7개까지 설정할 수 있습니다."),
     EXCEED_TAG_LENGTH(HttpStatus.BAD_REQUEST, "태그는 최대 20글자까지 입력할 수 있습니다."),
 
     EMPTY_DESCRIPTION(HttpStatus.BAD_REQUEST, "소개는 공백일 수 없습니다."),
@@ -36,7 +36,9 @@ public enum ErrorCode {
     NOT_EXIST_BOARD(HttpStatus.NOT_FOUND, "존재하지 않는 콘텐츠입니다."),
     NOT_EXIST_CREATOR(HttpStatus.NOT_FOUND, "존재하지 않는 크리에이터입니다."),
     NOT_EXIST_MEMBER(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
-    NOT_EXIST_SHORTS(HttpStatus.NOT_FOUND, "존재하지 않는 숏클래스입니다.");
+    NOT_EXIST_SHORTS(HttpStatus.NOT_FOUND, "존재하지 않는 숏클래스입니다."),
+
+    NOT_EMPTY_TAG(HttpStatus.BAD_REQUEST, "태그는 최소 1개 이상 설정돼야 합니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/croundteam/cround/common/fixtures/ConstantFixtures.java
+++ b/src/main/java/croundteam/cround/common/fixtures/ConstantFixtures.java
@@ -6,6 +6,8 @@ public final class ConstantFixtures {
 
     public static final String DEFAULT_PROFILE_IMAGE = "https://avatars.githubusercontent.com/u/132455714?s=400&u=b9befff0d433aa7f0eaf9927a4e6f55af3fe9986&v=4";
     public static final String CREATOR_PLATFORM_URI = "https://www.youtube.com/@youngji_boxmedia";
+
     public static final int CREATOR_TAGS_MAX_SIZE = 7;
     public static final int CREATOR_TAG_MAX_LENGTH = 20;
+    public static final int CREATOR_TAGS_MIN_SIZE = 1;
 }

--- a/src/main/java/croundteam/cround/config/QueryDslConfig.java
+++ b/src/main/java/croundteam/cround/config/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package croundteam.cround.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/croundteam/cround/config/SecurityConfig.java
+++ b/src/main/java/croundteam/cround/config/SecurityConfig.java
@@ -62,9 +62,12 @@ public class SecurityConfig {
         http
                 .authorizeRequests()
                 .antMatchers("/", "/css/**", "/images/**", "/js/**", "/h2-console/**", "/favicon.ico", "/error").permitAll()
-                .antMatchers("/login", "/cround/health", "/cround/login", "/oauth2/authorize/**").permitAll()
-                .antMatchers(HttpMethod.GET, "/oauth2/kakao", "/auth/kakao/login", "/**").permitAll()
-                .antMatchers(HttpMethod.POST, "/api/members", "/auth/login").permitAll()
+                .antMatchers("/cround/health").permitAll()
+                .antMatchers(
+                        HttpMethod.GET, "/auth/kakao/login",
+                        "/api/boards", "/api/creators")
+                .permitAll()
+                .antMatchers(HttpMethod.POST, "/auth/login", "/api/members").permitAll()
                 .anyRequest().authenticated();
 
         http

--- a/src/main/java/croundteam/cround/creator/controller/CreatorController.java
+++ b/src/main/java/croundteam/cround/creator/controller/CreatorController.java
@@ -4,6 +4,8 @@ import croundteam.cround.creator.service.dto.CreatorSearchResponse;
 import croundteam.cround.creator.service.dto.SearchCreatorCondition;
 import croundteam.cround.creator.service.CreatorService;
 import croundteam.cround.creator.service.dto.CreatorSaveRequest;
+import croundteam.cround.member.service.dto.LoginMember;
+import croundteam.cround.security.token.support.Login;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -21,12 +23,12 @@ public class CreatorController {
 
     private final CreatorService creatorService;
 
-    @PostMapping("/{memberId}")
+    @PostMapping
     public ResponseEntity<Void> createCreator(
-            @PathVariable Long memberId,
+            @Login LoginMember member,
             @RequestBody CreatorSaveRequest creatorSaveRequest
     ) {
-        String activityName = creatorService.createCreator(memberId, creatorSaveRequest);
+        String activityName = creatorService.createCreator(member, creatorSaveRequest);
         return ResponseEntity.created(URI.create("/api/creators/" + activityName)).build();
     }
 

--- a/src/main/java/croundteam/cround/creator/controller/CreatorController.java
+++ b/src/main/java/croundteam/cround/creator/controller/CreatorController.java
@@ -1,9 +1,13 @@
 package croundteam.cround.creator.controller;
 
+import croundteam.cround.creator.service.dto.CreatorSearchResponse;
+import croundteam.cround.creator.service.dto.SearchCreatorCondition;
 import croundteam.cround.creator.service.CreatorService;
 import croundteam.cround.creator.service.dto.CreatorSaveRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -24,5 +28,14 @@ public class CreatorController {
     ) {
         String activityName = creatorService.createCreator(memberId, creatorSaveRequest);
         return ResponseEntity.created(URI.create("/api/creators/" + activityName)).build();
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<CreatorSearchResponse>> searchCreators(
+            SearchCreatorCondition searchCreatorCondition,
+            CustomPageRequest customPageRequest
+    ) {
+        PageRequest pageRequest = customPageRequest.toPageRequest();
+        return ResponseEntity.ok(creatorService.searchCreatorsByCondition(searchCreatorCondition, pageRequest));
     }
 }

--- a/src/main/java/croundteam/cround/creator/controller/CustomPageRequest.java
+++ b/src/main/java/croundteam/cround/creator/controller/CustomPageRequest.java
@@ -1,0 +1,21 @@
+package croundteam.cround.creator.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.domain.PageRequest;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter @Setter
+public class CustomPageRequest {
+
+    private final int DEFAULT_SIZE = 10;
+
+    private int page;
+
+    public PageRequest toPageRequest() {
+        return PageRequest.of(page, DEFAULT_SIZE);
+    }
+}

--- a/src/main/java/croundteam/cround/creator/domain/Creator.java
+++ b/src/main/java/croundteam/cround/creator/domain/Creator.java
@@ -21,7 +21,9 @@ import java.util.List;
 @Getter
 @Table(uniqueConstraints = @UniqueConstraint(
         name = "creator_member_unique",
-        columnNames="member_id"))
+        columnNames="member_id"),
+        indexes = @Index(name = "idx_platform_activity_name", columnList = "platform_activity_name", unique = true))
+// SELECT * FROM INFORMATION_SCHEMA.INDEXES where INDEX_NAME = 'IDX_PLATFORM_ACTIVITY_NAME';
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Creator extends BaseTime {
 

--- a/src/main/java/croundteam/cround/creator/domain/Creator.java
+++ b/src/main/java/croundteam/cround/creator/domain/Creator.java
@@ -82,7 +82,7 @@ public class Creator extends BaseTime {
     }
 
     public void addShorts(Shorts shorts) {
-
+        this.shorts.add(shorts);
     }
 
     public void addFollow(Follow follow) {
@@ -99,5 +99,9 @@ public class Creator extends BaseTime {
 
     public Long getMemberId() {
         return member.getId();
+    }
+
+    public String getDescription() {
+        return description.getDescription();
     }
 }

--- a/src/main/java/croundteam/cround/creator/domain/Creator.java
+++ b/src/main/java/croundteam/cround/creator/domain/Creator.java
@@ -16,7 +16,6 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Entity
 @Getter
@@ -57,26 +56,20 @@ public class Creator extends BaseTime {
     private List<Shorts> shorts = new ArrayList<>();
 
     @Builder
-    private Creator(String profileImage, Member member, Platform platform, Tags creatorTags, Description description) {
+    private Creator(String profileImage, Member member, Platform platform, Tags tags, Description description) {
         this.profileImage = profileImage;
         this.member = member;
         this.platform = platform;
-        this.creatorTags = castTagsToCreatorTags(creatorTags);
+        this.creatorTags = tags.castCreatorTagsFromTags(this);
         this.description = description;
     }
 
-    private List<CreatorTag> castTagsToCreatorTags(Tags tags) {
-        return tags.toList().stream()
-                .map(tag -> CreatorTag.of(this, tag))
-                .collect(Collectors.toList());
-    }
-
-    public static Creator of(String profileImage, Member member, Platform platform, Tags creatorTags) {
+    public static Creator of(String profileImage, Member member, Platform platform, Tags tags) {
         return Creator.builder()
                 .profileImage(profileImage)
                 .member(member)
                 .platform(platform)
-                .creatorTags(creatorTags)
+                .tags(tags)
                 .build();
     }
 

--- a/src/main/java/croundteam/cround/creator/domain/Description.java
+++ b/src/main/java/croundteam/cround/creator/domain/Description.java
@@ -3,11 +3,13 @@ package croundteam.cround.creator.domain;
 import croundteam.cround.common.exception.ErrorCode;
 import croundteam.cround.creator.exception.InvalidDescriptionException;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Embeddable;
 import java.util.Objects;
 
+@Getter
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Description {

--- a/src/main/java/croundteam/cround/creator/domain/tag/Tags.java
+++ b/src/main/java/croundteam/cround/creator/domain/tag/Tags.java
@@ -1,23 +1,25 @@
 package croundteam.cround.creator.domain.tag;
 
 import croundteam.cround.common.exception.ErrorCode;
+import croundteam.cround.creator.domain.Creator;
+import croundteam.cround.creator.domain.CreatorTag;
 import croundteam.cround.creator.exception.ExceedTagLengthException;
 import croundteam.cround.creator.exception.ExceedTagsSizeException;
+import croundteam.cround.creator.exception.NotEmptyTagException;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static croundteam.cround.common.fixtures.ConstantFixtures.CREATOR_TAGS_MAX_SIZE;
-import static croundteam.cround.common.fixtures.ConstantFixtures.CREATOR_TAG_MAX_LENGTH;
+import static croundteam.cround.common.fixtures.ConstantFixtures.*;
 
 public class Tags {
 
     private List<Tag> tags;
 
     private Tags(List<Tag> tags) {
+        validateTagEmpty(tags);
         validateTagsSize(tags);
         validateTagLength(tags);
         this.tags = tags;
@@ -27,21 +29,21 @@ public class Tags {
         return new Tags(tags);
     }
 
-    public List<Tag> toList() {
-        return Collections.unmodifiableList(tags);
+    public static Tags from(String... names) {
+        List<Tag> tags = Arrays.stream(names).map(Tag::from).collect(Collectors.toList());
+        return new Tags(tags);
     }
 
-    public static Tags toTagsByNames(String... names) {
-        if(Objects.isNull(names)) {
-            /**
-             * TODO: 태그가 0개여도 가능한지 또는 무조건 1개 이상이어야 하는지에 대한 것도 구체화하기
-             * throws new NotEmptyTagException()
-             */
-        }
-        List<Tag> collect = Arrays.stream(names)
-                .map(name -> Tag.from(name))
+    public List<CreatorTag> castCreatorTagsFromTags(Creator creator) {
+        return tags.stream()
+                .map(tag -> CreatorTag.of(creator, tag))
                 .collect(Collectors.toList());
-        return new Tags(collect);
+    }
+
+    private void validateTagEmpty(List<Tag> tags) {
+        if(Objects.isNull(tags) || tags.isEmpty()) {
+            throw new NotEmptyTagException(ErrorCode.NOT_EMPTY_TAG);
+        }
     }
 
     private void validateTagLength(List<Tag> tags) {
@@ -53,8 +55,8 @@ public class Tags {
     }
 
     private void validateTagsSize(List<Tag> tags) {
-        if(tags.size() > CREATOR_TAGS_MAX_SIZE) {
-            throw new ExceedTagsSizeException(ErrorCode.EXCEED_TAGS_MAX_SIZE);
+        if(tags.size() > CREATOR_TAGS_MAX_SIZE || tags.size() < CREATOR_TAGS_MIN_SIZE) {
+            throw new ExceedTagsSizeException(ErrorCode.EXCEED_TAGS_SIZE);
         }
     }
 }

--- a/src/main/java/croundteam/cround/creator/exception/NotEmptyTagException.java
+++ b/src/main/java/croundteam/cround/creator/exception/NotEmptyTagException.java
@@ -1,0 +1,10 @@
+package croundteam.cround.creator.exception;
+
+import croundteam.cround.common.exception.BusinessException;
+import croundteam.cround.common.exception.ErrorCode;
+
+public class NotEmptyTagException extends BusinessException {
+    public NotEmptyTagException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/croundteam/cround/creator/repository/CreatorQueryRepository.java
+++ b/src/main/java/croundteam/cround/creator/repository/CreatorQueryRepository.java
@@ -1,0 +1,12 @@
+package croundteam.cround.creator.repository;
+
+import croundteam.cround.creator.domain.Creator;
+import croundteam.cround.creator.service.dto.SearchCreatorCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CreatorQueryRepository {
+
+    Page<Creator> searchCreatorByKeywordAndPlatforms(SearchCreatorCondition searchCreatorCondition, Pageable pageable);
+
+}

--- a/src/main/java/croundteam/cround/creator/repository/CreatorQueryRepository.java
+++ b/src/main/java/croundteam/cround/creator/repository/CreatorQueryRepository.java
@@ -1,12 +1,13 @@
 package croundteam.cround.creator.repository;
 
 import croundteam.cround.creator.domain.Creator;
-import croundteam.cround.creator.service.dto.SearchCreatorCondition;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface CreatorQueryRepository {
 
-    Page<Creator> searchCreatorByKeywordAndPlatforms(SearchCreatorCondition searchCreatorCondition, Pageable pageable);
+    Page<Creator> searchCreatorByKeywordAndPlatforms(List<String> platforms, String keyword, Pageable pageable);
 
 }

--- a/src/main/java/croundteam/cround/creator/repository/CreatorQueryRepositoryImpl.java
+++ b/src/main/java/croundteam/cround/creator/repository/CreatorQueryRepositoryImpl.java
@@ -4,7 +4,6 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import croundteam.cround.creator.domain.Creator;
-import croundteam.cround.creator.service.dto.SearchCreatorCondition;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -14,6 +13,7 @@ import org.springframework.util.StringUtils;
 import java.util.List;
 
 import static croundteam.cround.creator.domain.QCreator.creator;
+import static croundteam.cround.creator.domain.tag.QTag.tag;
 
 public class CreatorQueryRepositoryImpl extends QuerydslRepositorySupport implements CreatorQueryRepository {
 
@@ -28,30 +28,41 @@ public class CreatorQueryRepositoryImpl extends QuerydslRepositorySupport implem
      * 1. 키워드를 검색한다. or 연산으로 creator의 태그와, creator의 이름으로
      */
     @Override
-    public Page<Creator> searchCreatorByKeywordAndPlatforms(
-            SearchCreatorCondition searchCreatorCondition,
-            Pageable pageable
-    ) {
-        System.out.println("searchCreatorCondition = " + searchCreatorCondition);
+    public Page<Creator> searchCreatorByKeywordAndPlatforms(List<String> platforms, String keyword, Pageable pageable) {
+        System.out.println("platforms = " + platforms);
+        System.out.println("keyword = " + keyword);
         System.out.println("pageable = " + pageable);
+
+        List<Long> tagIds = jpaQueryFactory
+                .select(tag.id)
+                .from(tag)
+                .where(containsTagName(keyword))
+                .fetch();
+
         JPAQuery<Creator> query = jpaQueryFactory
                 .selectFrom(creator)
-                .where(whereKeywords(searchCreatorCondition.getKeyword()));
+                .where(whereKeywords(keyword, tagIds));
 
         List<Creator> creators = getQuerydsl().applyPagination(pageable, query).fetch();
 
         return new PageImpl<>(creators, pageable, creators.size());
     }
 
-    private BooleanExpression whereKeywords(String keyword) {
-        /**
-         * contains와 like의 차이
-         */
+    private BooleanExpression containsTagName(String keyword) {
+        if(!StringUtils.hasText(keyword) || keyword.isEmpty()) {
+            return null;
+        }
+        return tag.tagName.name.contains(keyword);
+    }
+
+    private BooleanExpression whereKeywords(String keyword, List<Long> tagIds) {
+         // contains와 like의 차이
         if(!StringUtils.hasText(keyword) || keyword.isEmpty()) {
             return null;
         }
         BooleanExpression containName = creator.platform.platformActivityName.name.contains(keyword);
+        BooleanExpression containTagName = creator.creatorTags.any().id.in(tagIds);
 
-        return containName;
+        return containName.or(containTagName);
     }
 }

--- a/src/main/java/croundteam/cround/creator/repository/CreatorQueryRepositoryImpl.java
+++ b/src/main/java/croundteam/cround/creator/repository/CreatorQueryRepositoryImpl.java
@@ -1,0 +1,57 @@
+package croundteam.cround.creator.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import croundteam.cround.creator.domain.Creator;
+import croundteam.cround.creator.service.dto.SearchCreatorCondition;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+import org.springframework.util.StringUtils;
+
+import java.util.List;
+
+import static croundteam.cround.creator.domain.QCreator.creator;
+
+public class CreatorQueryRepositoryImpl extends QuerydslRepositorySupport implements CreatorQueryRepository {
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public CreatorQueryRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+        super(Creator.class);
+        this.jpaQueryFactory = jpaQueryFactory;
+    }
+
+    /**
+     * 1. 키워드를 검색한다. or 연산으로 creator의 태그와, creator의 이름으로
+     */
+    @Override
+    public Page<Creator> searchCreatorByKeywordAndPlatforms(
+            SearchCreatorCondition searchCreatorCondition,
+            Pageable pageable
+    ) {
+        System.out.println("searchCreatorCondition = " + searchCreatorCondition);
+        System.out.println("pageable = " + pageable);
+        JPAQuery<Creator> query = jpaQueryFactory
+                .selectFrom(creator)
+                .where(whereKeywords(searchCreatorCondition.getKeyword()));
+
+        List<Creator> creators = getQuerydsl().applyPagination(pageable, query).fetch();
+
+        return new PageImpl<>(creators, pageable, creators.size());
+    }
+
+    private BooleanExpression whereKeywords(String keyword) {
+        /**
+         * contains와 like의 차이
+         */
+        if(!StringUtils.hasText(keyword) || keyword.isEmpty()) {
+            return null;
+        }
+        BooleanExpression containName = creator.platform.platformActivityName.name.contains(keyword);
+
+        return containName;
+    }
+}

--- a/src/main/java/croundteam/cround/creator/repository/CreatorRepository.java
+++ b/src/main/java/croundteam/cround/creator/repository/CreatorRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
-public interface CreatorRepository extends JpaRepository<Creator, Long> {
+public interface CreatorRepository extends JpaRepository<Creator, Long>, CreatorQueryRepository {
 
     boolean existsByPlatformPlatformActivityNameName(String platformActivityName);
 

--- a/src/main/java/croundteam/cround/creator/service/CreatorService.java
+++ b/src/main/java/croundteam/cround/creator/service/CreatorService.java
@@ -10,6 +10,7 @@ import croundteam.cround.creator.service.dto.SearchCreatorCondition;
 import croundteam.cround.member.domain.Member;
 import croundteam.cround.member.exception.NotExistMemberException;
 import croundteam.cround.member.repository.MemberRepository;
+import croundteam.cround.member.service.dto.LoginMember;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -27,10 +28,10 @@ public class CreatorService {
     private final CreatorRepository creatorRepository;
 
     @Transactional
-    public String createCreator(Long memberId, CreatorSaveRequest creatorSaveRequest) {
+    public String createCreator(LoginMember loginMember, CreatorSaveRequest creatorSaveRequest) {
         validateCreator(creatorSaveRequest);
 
-        Member member = findMemberById(memberId);
+        Member member = findMemberByEmail(loginMember.getEmail());
         Creator creator = creatorSaveRequest.toEntity();
         creator.addMember(member);
 
@@ -44,7 +45,8 @@ public class CreatorService {
             SearchCreatorCondition searchCreatorCondition,
             Pageable pageable
     ) {
-        Page<Creator> creators = creatorRepository.searchCreatorByKeywordAndPlatforms(searchCreatorCondition, pageable);
+        Page<Creator> creators = creatorRepository.searchCreatorByKeywordAndPlatforms(
+                searchCreatorCondition.getPlatforms(), searchCreatorCondition.getKeyword(), pageable);
         return creators.map(CreatorSearchResponse::from);
     }
 
@@ -54,8 +56,8 @@ public class CreatorService {
         }
     }
 
-    private Member findMemberById(Long memberId) {
-        return memberRepository.findById(memberId).orElseThrow(
+    private Member findMemberByEmail(String email) {
+        return memberRepository.findByEmail(email).orElseThrow(
                 () -> new NotExistMemberException(ErrorCode.NOT_EXIST_MEMBER));
     }
 }

--- a/src/main/java/croundteam/cround/creator/service/CreatorService.java
+++ b/src/main/java/croundteam/cround/creator/service/CreatorService.java
@@ -5,23 +5,28 @@ import croundteam.cround.creator.domain.Creator;
 import croundteam.cround.creator.exception.DuplicateCreatorPlatformActivityNameException;
 import croundteam.cround.creator.repository.CreatorRepository;
 import croundteam.cround.creator.service.dto.CreatorSaveRequest;
+import croundteam.cround.creator.service.dto.CreatorSearchResponse;
+import croundteam.cround.creator.service.dto.SearchCreatorCondition;
 import croundteam.cround.member.domain.Member;
 import croundteam.cround.member.exception.NotExistMemberException;
 import croundteam.cround.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
-@Transactional
+@Transactional(readOnly = true)
 public class CreatorService {
 
     private final MemberRepository memberRepository;
     private final CreatorRepository creatorRepository;
 
+    @Transactional
     public String createCreator(Long memberId, CreatorSaveRequest creatorSaveRequest) {
         validateCreator(creatorSaveRequest);
 
@@ -32,6 +37,15 @@ public class CreatorService {
         Creator saveCreator = creatorRepository.save(creator);
 
         return saveCreator.getActivityName();
+    }
+
+
+    public Page<CreatorSearchResponse> searchCreatorsByCondition(
+            SearchCreatorCondition searchCreatorCondition,
+            Pageable pageable
+    ) {
+        Page<Creator> creators = creatorRepository.searchCreatorByKeywordAndPlatforms(searchCreatorCondition, pageable);
+        return creators.map(CreatorSearchResponse::from);
     }
 
     private void validateCreator(CreatorSaveRequest creatorSaveRequest) {

--- a/src/main/java/croundteam/cround/creator/service/dto/CreatorSaveRequest.java
+++ b/src/main/java/croundteam/cround/creator/service/dto/CreatorSaveRequest.java
@@ -28,7 +28,7 @@ public class CreatorSaveRequest {
         return Creator.builder()
                 .profileImage(profileImage)
                 .platform(Platform.of(platformUrl, platformType, platformActivityName))
-                .creatorTags(Tags.from(tags))
+                .tags(Tags.from(tags))
                 .description(Description.create(description))
                 .build();
     }

--- a/src/main/java/croundteam/cround/creator/service/dto/CreatorSearchResponse.java
+++ b/src/main/java/croundteam/cround/creator/service/dto/CreatorSearchResponse.java
@@ -1,0 +1,37 @@
+package croundteam.cround.creator.service.dto;
+
+import croundteam.cround.creator.domain.Creator;
+import croundteam.cround.creator.domain.platform.Platform;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CreatorSearchResponse {
+
+    private Long creatorId;
+    private String platformActivityName;
+    private String description;
+    private String profileImage;
+    private String platformType;
+
+    @Builder
+    public CreatorSearchResponse(Long creatorId, String platformActivityName, String description, String profileImage, String platformType) {
+        this.creatorId = creatorId;
+        this.platformActivityName = platformActivityName;
+        this.description = description;
+        this.profileImage = profileImage;
+        this.platformType = platformType;
+    }
+
+    public static CreatorSearchResponse from(Creator creator) {
+        return CreatorSearchResponse.builder()
+                .creatorId(creator.getId())
+                .platformActivityName(creator.getActivityName())
+                .description(creator.getDescription())
+                .profileImage(creator.getProfileImage())
+                .platformType(creator.getPlatform().getPlatformType())
+                .build();
+    }
+}

--- a/src/main/java/croundteam/cround/creator/service/dto/SearchCreatorCondition.java
+++ b/src/main/java/croundteam/cround/creator/service/dto/SearchCreatorCondition.java
@@ -1,0 +1,15 @@
+package croundteam.cround.creator.service.dto;
+
+import croundteam.cround.creator.domain.platform.PlatformType;
+import lombok.*;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+@Getter @Setter
+public class SearchCreatorCondition {
+    // private List<PlatformType> platformTypes;
+    private String keyword;
+}

--- a/src/main/java/croundteam/cround/creator/service/dto/SearchCreatorCondition.java
+++ b/src/main/java/croundteam/cround/creator/service/dto/SearchCreatorCondition.java
@@ -1,6 +1,5 @@
 package croundteam.cround.creator.service.dto;
 
-import croundteam.cround.creator.domain.platform.PlatformType;
 import lombok.*;
 
 import java.util.List;
@@ -10,6 +9,6 @@ import java.util.List;
 @ToString
 @Getter @Setter
 public class SearchCreatorCondition {
-    // private List<PlatformType> platformTypes;
+    private List<String> platforms;
     private String keyword;
 }

--- a/src/main/java/croundteam/cround/member/service/dto/LoginMember.java
+++ b/src/main/java/croundteam/cround/member/service/dto/LoginMember.java
@@ -1,6 +1,7 @@
 package croundteam.cround.member.service.dto;
 
 public class LoginMember {
+
     private String email;
 
     public LoginMember(String email) {

--- a/src/main/java/croundteam/cround/shorts/domain/Shorts.java
+++ b/src/main/java/croundteam/cround/shorts/domain/Shorts.java
@@ -2,6 +2,7 @@ package croundteam.cround.shorts.domain;
 
 import croundteam.cround.board.domain.Content;
 import croundteam.cround.board.domain.Title;
+import croundteam.cround.common.domain.BaseTime;
 import croundteam.cround.creator.domain.Creator;
 import croundteam.cround.creator.domain.platform.PlatformType;
 import croundteam.cround.member.domain.Member;
@@ -17,7 +18,7 @@ import javax.persistence.*;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "shorts_class")
-public class Shorts {
+public class Shorts extends BaseTime {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/test/java/croundteam/cround/creator/domain/CreatorTest.java
+++ b/src/test/java/croundteam/cround/creator/domain/CreatorTest.java
@@ -1,9 +1,9 @@
 package croundteam.cround.creator.domain;
 
 import croundteam.cround.creator.domain.platform.Platform;
+import croundteam.cround.creator.domain.tag.Tags;
 import croundteam.cround.creator.repository.CreatorRepository;
 import croundteam.cround.member.domain.Member;
-import croundteam.cround.creator.domain.tag.Tags;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,7 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import static croundteam.cround.common.fixtures.ConstantFixtures.CREATOR_PLATFORM_URI;
 import static croundteam.cround.common.fixtures.ConstantFixtures.DEFAULT_PROFILE_IMAGE;
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
@@ -34,7 +34,7 @@ class CreatorTest {
                 .build();
 
         Platform platform = Platform.of(CREATOR_PLATFORM_URI, "instagram", "crounder");
-        Tags tags = Tags.toTagsByNames("크라운드 대표", "크라운드 직원");
+        Tags tags = Tags.from("크라운드 대표", "크라운드 직원");
 
         // when
         Creator creator = Creator.of(DEFAULT_PROFILE_IMAGE, member, platform, tags);


### PR DESCRIPTION
## 기능 설명
- Tags에 검증 로직 추가
- 크리에이터 검색 API 추가
- 크리에이터 활동명에 인덱스 추가
- QueryDSL-JPA 추가

## 기능 상세
- [x] QueryDSL-JPA 추가
- [x] 크리에이터를 나타내는 태그가 1개 이상 존재해야 하는 검증 로직 추가
- [x] 크리에이터 검색 API 추가
    - [x] 검색 조건은 이름, 크리에이터의 태그명
- [x] 크리에이터 활동명에 인덱스 추가
- [x] 크리에이터 검색 api를 permit 설정