### PR TITLE
feat: 반환 타입이 List인 getFilter에 null이 아닌 빈 리스트를 반환하고, 조인 후 order by로 변경 (#88)

### DIFF
--- a/src/main/java/croundteam/cround/creator/repository/CreatorQueryRepository.java
+++ b/src/main/java/croundteam/cround/creator/repository/CreatorQueryRepository.java
@@ -57,8 +57,8 @@ public class CreatorQueryRepository {
             case FOLLOW:
                 return query
                         .leftJoin(creator.followers.followers, follow)
-                        .groupBy(creator.id)
-                        .orderBy(follow.id.count().desc(), creator.id.desc())
+                        .groupBy(creator)
+                        .orderBy(follow.id.sum().desc(), creator.id.desc())
                         .fetch();
         }
         throw new InvalidSortTypeException(ErrorCode.INVALID_SORT_TYPE);

--- a/src/main/java/croundteam/cround/shorts/domain/Shorts.java
+++ b/src/main/java/croundteam/cround/shorts/domain/Shorts.java
@@ -67,7 +67,8 @@ public class Shorts extends BaseTime {
                 .title(Title.create(shortsSaveRequest.getTitle()))
                 .content(Content.create(shortsSaveRequest.getContent()))
                 .platformType(PlatformType.create(shortsSaveRequest.getPlatformType()))
-                .thumbnailUrl(ThumbnailUrl.create(shortsSaveRequest.getShortsUrl()))
+                .thumbnailUrl(ThumbnailUrl.create(shortsSaveRequest.getThumbnailUrl()))
+                .shortsUrl(ShortsUrl.create(shortsSaveRequest.getShortsUrl()))
                 .creator(creator)
                 .build();
     }
@@ -97,7 +98,7 @@ public class Shorts extends BaseTime {
     }
 
     public String getThumbnailUrl() {
-        return thumbnailUrl.getUrl();
+        return thumbnailUrl.getThumbnailUrl();
     }
 
     public String getTitle() {

--- a/src/main/java/croundteam/cround/shorts/domain/ThumbnailUrl.java
+++ b/src/main/java/croundteam/cround/shorts/domain/ThumbnailUrl.java
@@ -21,7 +21,7 @@ public class ThumbnailUrl {
         return new ThumbnailUrl(shortsUrl);
     }
 
-    public String getUrl() {
+    public String getThumbnailUrl() {
         return url;
     }
 }

--- a/src/main/java/croundteam/cround/shorts/repository/ShortsQueryRepository.java
+++ b/src/main/java/croundteam/cround/shorts/repository/ShortsQueryRepository.java
@@ -9,6 +9,8 @@ import croundteam.cround.common.exception.ErrorCode;
 import croundteam.cround.common.repository.RepositorySupport;
 import croundteam.cround.creator.domain.platform.PlatformName;
 import croundteam.cround.creator.exception.InvalidSortTypeException;
+import croundteam.cround.shorts.domain.QShortsBookmark;
+import croundteam.cround.shorts.domain.QShortsLike;
 import croundteam.cround.shorts.domain.Shorts;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -21,6 +23,8 @@ import java.util.Objects;
 import static croundteam.cround.common.dto.SearchCondition.ContentSortCondition;
 import static croundteam.cround.creator.domain.QCreator.creator;
 import static croundteam.cround.shorts.domain.QShorts.shorts;
+import static croundteam.cround.shorts.domain.QShortsBookmark.*;
+import static croundteam.cround.shorts.domain.QShortsLike.*;
 
 @Repository
 public class ShortsQueryRepository {
@@ -57,11 +61,15 @@ public class ShortsQueryRepository {
                         .fetch();
             case LIKE:
                 return query
-                        .orderBy(shorts.shortsLikes.shortsLikes.size().desc(), shorts.id.desc())
+                        .leftJoin(shorts.shortsLikes.shortsLikes, shortsLike)
+                        .groupBy(shorts)
+                        .orderBy(shortsLike.shorts.id.sum().desc(), shorts.id.desc())
                         .fetch();
             case BOOKMARK:
                 return query
-                        .orderBy(shorts.shortsBookmarks.shortsBookmarks.size().desc(), shorts.id.desc())
+                        .leftJoin(shorts.shortsBookmarks.shortsBookmarks, shortsBookmark)
+                        .groupBy(shorts)
+                        .orderBy(shortsBookmark.id.sum().desc(), shorts.id.desc())
                         .fetch();
         }
         throw new InvalidSortTypeException(ErrorCode.INVALID_SORT_TYPE);

--- a/src/main/java/croundteam/cround/shorts/service/dto/ShortsSaveRequest.java
+++ b/src/main/java/croundteam/cround/shorts/service/dto/ShortsSaveRequest.java
@@ -12,4 +12,5 @@ public class ShortsSaveRequest {
     private String title;
     private String content;
     private String shortsUrl;
+    private String thumbnailUrl;
 }


### PR DESCRIPTION
## 기능 설명
반환 타입이 List인 getFilter에 null이 아닌 빈 리스트를 반환하고, 조인 후 order by로 변경

## 기능 상세
- [x] null보다는 빈 리스트를 반환하도록 변경하고 그에 맞는 조건식으로 변경한다
- [x] 숏클래스와 콘텐츠의 목록 조회를 조인 후 order by로 변경
