### PR TITLE
feat: 메인페이지 크리에이터 및 숏클래스 인기 항목 조회 추가 (#88, #118)

### DIFF
--- a/src/main/java/croundteam/cround/common/advice/ControllerAdvice.java
+++ b/src/main/java/croundteam/cround/common/advice/ControllerAdvice.java
@@ -23,9 +23,12 @@ public class ControllerAdvice {
     }
     
     @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e, HttpServletRequest request) {
         ErrorCode errorCode = e.getErrorCode();
-        log.info("error code = {}, message = {}", errorCode.getStatus(), errorCode.getMessage());
+
+        String method = request.getMethod();
+        String requestURI = request.getRequestURI();
+        log.info("ERROR {}: [{}][{}]: Exception Message = {}", errorCode.getStatus(), method, requestURI, errorCode.getMessage());
         return ResponseEntity.status(errorCode.getStatus()).body(new ErrorResponse(errorCode.getMessage()));
     }
 

--- a/src/main/java/croundteam/cround/config/SecurityConfig.java
+++ b/src/main/java/croundteam/cround/config/SecurityConfig.java
@@ -67,7 +67,8 @@ public class SecurityConfig {
                         HttpMethod.GET, "/auth/kakao/login",
                         "/api/boards", "/api/boards/{boardId}", "/api/creators", "/api/creators/{creatorId}",
                         "/api/shorts", "/api/shorts/{shortsId}",
-                        "/api/creators/{creatorId}/reviews", "/api/creators/{creatorId}/boards", "/api/creators/{creatorId}/shorts")
+                        "/api/creators/{creatorId}/reviews", "/api/creators/{creatorId}/boards",
+                        "/api/creators/{creatorId}/shorts", "/api/creators/home")
                 .permitAll()
                 .antMatchers(HttpMethod.POST, "/auth/login", "/api/members",
                         "/api/members/validations/email", "/api/members/validations/nickname").permitAll()

--- a/src/main/java/croundteam/cround/creator/application/CreatorService.java
+++ b/src/main/java/croundteam/cround/creator/application/CreatorService.java
@@ -104,20 +104,13 @@ public class CreatorService {
         return new SearchBoardsResponses(boards, member);
     }
 
-    /**
-     * 크리에이터 최신순
-     *
-     * @return
-     */
     public FindHomeCreators findHomeCreators(int size, AppUser appUser) {
         Long totalCount = creatorRepository.countBy();
-        Pageable pageable = PageRequest.ofSize(size);
-
         Member member = getLoginMember(appUser);
 
-        List<Creator> latestCreators = creatorRepository.findCreatorBy(pageable);
+        List<Creator> latestCreators = creatorRepository.findCreatorBy(PageRequest.ofSize(size));
         List<Creator> interestCreators = creatorQueryRepository.findCreatorByMember(size, getInterestPlatformBy(member));
-        List<Creator> randomCreators = creatorRepository.findCreatorByRandom(createRandomBy(totalCount, size), pageable);
+        List<Creator> randomCreators = creatorRepository.findCreatorByRandom(createRandomBy(totalCount, size));
 
         return new FindHomeCreators(latestCreators, interestCreators, randomCreators);
     }

--- a/src/main/java/croundteam/cround/creator/application/dto/FindHomeCreators.java
+++ b/src/main/java/croundteam/cround/creator/application/dto/FindHomeCreators.java
@@ -1,0 +1,29 @@
+package croundteam.cround.creator.application.dto;
+
+import croundteam.cround.creator.domain.Creator;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static java.util.stream.Collectors.toList;
+
+@Getter
+@NoArgsConstructor
+public class FindHomeCreators {
+
+    List<SearchCreatorResponse> latestCreators = new ArrayList<>();
+    List<SearchCreatorResponse> interestCreators = new ArrayList<>();
+    List<SearchCreatorResponse> randomCreators = new ArrayList<>();
+
+    public FindHomeCreators(List<Creator> latestCreators, List<Creator> interestCreators, List<Creator> randomCreators) {
+        this.latestCreators = convertToSearchCreatorResponse(latestCreators);
+        this.interestCreators = convertToSearchCreatorResponse(interestCreators);
+        this.randomCreators = convertToSearchCreatorResponse(randomCreators);
+    }
+
+    private static List<SearchCreatorResponse> convertToSearchCreatorResponse(List<Creator> creators) {
+        return creators.stream().map(SearchCreatorResponse::from).collect(toList());
+    }
+}

--- a/src/main/java/croundteam/cround/creator/domain/CreatorRepository.java
+++ b/src/main/java/croundteam/cround/creator/domain/CreatorRepository.java
@@ -1,10 +1,11 @@
 package croundteam.cround.creator.domain;
 
-import croundteam.cround.creator.domain.Creator;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface CreatorRepository extends JpaRepository<Creator, Long> {
@@ -19,4 +20,13 @@ public interface CreatorRepository extends JpaRepository<Creator, Long> {
             "join fetch c.activityPlatforms.platformTypes " +
             "WHERE c.id = :creatorId")
     Optional<Creator> findCreatorById(@Param("creatorId") Long creatorId);
+
+    @Query("SELECT c FROM Creator c " +
+            "ORDER BY c.id desc")
+    List<Creator> findCreatorBy(Pageable pageable);
+
+    Long countBy();
+
+    @Query("SELECT c FROM Creator c WHERE c.id IN (:randomBy)")
+    List<Creator> findCreatorByRandom(@Param("randomBy") List<Long> randomBy, Pageable pageable);
 }

--- a/src/main/java/croundteam/cround/creator/domain/CreatorRepository.java
+++ b/src/main/java/croundteam/cround/creator/domain/CreatorRepository.java
@@ -28,5 +28,5 @@ public interface CreatorRepository extends JpaRepository<Creator, Long> {
     Long countBy();
 
     @Query("SELECT c FROM Creator c WHERE c.id IN (:randomBy)")
-    List<Creator> findCreatorByRandom(@Param("randomBy") List<Long> randomBy, Pageable pageable);
+    List<Creator> findCreatorByRandom(@Param("randomBy") List<Long> randomBy);
 }

--- a/src/main/java/croundteam/cround/creator/presentation/CreatorController.java
+++ b/src/main/java/croundteam/cround/creator/presentation/CreatorController.java
@@ -4,6 +4,7 @@ import croundteam.cround.board.application.dto.SearchBoardsResponses;
 import croundteam.cround.creator.application.CreatorService;
 import croundteam.cround.creator.application.dto.CreatorSaveRequest;
 import croundteam.cround.creator.application.dto.FindCreatorResponse;
+import croundteam.cround.creator.application.dto.FindHomeCreators;
 import croundteam.cround.creator.application.dto.SearchCreatorResponses;
 import croundteam.cround.member.application.dto.NicknameValidationRequest;
 import croundteam.cround.shortform.application.dto.SearchShortFormResponses;
@@ -52,6 +53,16 @@ public class CreatorController {
     @GetMapping("/{creatorId}")
     public ResponseEntity<FindCreatorResponse> findOne(@PathVariable Long creatorId, @Authenticated AppUser appUser) {
         return ResponseEntity.ok(creatorService.findOne(appUser, creatorId));
+    }
+
+    @GetMapping("/home")
+    public ResponseEntity<FindHomeCreators> findHomeCreators(
+            @RequestParam(name = "size", defaultValue = "4") int size,
+            @Authenticated AppUser appUser
+    ) {
+        FindHomeCreators findHomeCreators = creatorService.findHomeCreators(size, appUser);
+
+        return ResponseEntity.ok(findHomeCreators);
     }
 
     @GetMapping("/{creatorId}/shorts")

--- a/src/main/java/croundteam/cround/member/domain/InterestPlatforms.java
+++ b/src/main/java/croundteam/cround/member/domain/InterestPlatforms.java
@@ -6,7 +6,9 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -26,5 +28,16 @@ public class InterestPlatforms {
 
     public static InterestPlatforms create(List<PlatformType> platformTypes) {
         return new InterestPlatforms(platformTypes);
+    }
+
+    public List<String> castPlatformTypes() {
+        if(interestPlatforms.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return interestPlatforms
+                .stream()
+                .map(PlatformType::getType)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/croundteam/cround/member/domain/Member.java
+++ b/src/main/java/croundteam/cround/member/domain/Member.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Getter
@@ -82,5 +83,9 @@ public class Member extends BaseTime {
 
     public String getRoleName() {
         return role.getName();
+    }
+
+    public List<String> getInterestPlatforms() {
+        return interestPlatforms.castPlatformTypes();
     }
 }

--- a/src/main/java/croundteam/cround/shortform/application/ShortFormService.java
+++ b/src/main/java/croundteam/cround/shortform/application/ShortFormService.java
@@ -1,23 +1,23 @@
 package croundteam.cround.shortform.application;
 
-import croundteam.cround.shortform.application.dto.FindPopularShortForms;
-import croundteam.cround.support.search.SearchCondition;
 import croundteam.cround.common.exception.ErrorCode;
 import croundteam.cround.creator.domain.Creator;
-import croundteam.cround.creator.exception.NotExistCreatorException;
 import croundteam.cround.creator.domain.CreatorRepository;
+import croundteam.cround.creator.exception.NotExistCreatorException;
 import croundteam.cround.infra.S3Uploader;
 import croundteam.cround.member.domain.Member;
-import croundteam.cround.member.exception.NotExistMemberException;
 import croundteam.cround.member.domain.MemberRepository;
-import croundteam.cround.support.vo.AppUser;
-import croundteam.cround.support.vo.LoginMember;
+import croundteam.cround.member.exception.NotExistMemberException;
+import croundteam.cround.shortform.application.dto.FindPopularShortForms;
 import croundteam.cround.shortform.application.dto.FindShortFormResponse;
 import croundteam.cround.shortform.application.dto.SearchShortFormResponses;
 import croundteam.cround.shortform.application.dto.ShortFormSaveRequest;
 import croundteam.cround.shortform.domain.ShortForm;
 import croundteam.cround.shortform.domain.ShortFormQueryRepository;
 import croundteam.cround.shortform.domain.ShortFormRepository;
+import croundteam.cround.support.search.SearchCondition;
+import croundteam.cround.support.vo.AppUser;
+import croundteam.cround.support.vo.LoginMember;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -64,9 +64,11 @@ public class ShortFormService {
         return new SearchShortFormResponses(shortForms, member);
     }
 
+    @Transactional
     public FindShortFormResponse findOne(Long shortsId, AppUser appUser) {
         Member member = getLoginMember(appUser);
         ShortForm shortForm = shortFormRepository.findShortFormWithJoinById(shortsId);
+        shortForm.increaseVisit();
 
         return FindShortFormResponse.from(shortForm, member);
     }
@@ -74,10 +76,11 @@ public class ShortFormService {
     public FindPopularShortForms findPopularShortForm(int size, AppUser appUser) {
         Member member = getLoginMember(appUser);
 
+        List<ShortForm> popularVisitShortForms = shortFormQueryRepository.findPopularVisitShortForm(size);
         List<ShortForm> popularLikeShortForms = shortFormQueryRepository.findPopularLikeShortForm(size);
         List<ShortForm> popularBookmarkShortForms = shortFormQueryRepository.findPopularBookmarkShortForms(size);
 
-        return new FindPopularShortForms(popularLikeShortForms, popularBookmarkShortForms, member);
+        return new FindPopularShortForms(popularVisitShortForms, popularLikeShortForms, popularBookmarkShortForms, member);
     }
 
     private Member getLoginMember(AppUser appUser) {

--- a/src/main/java/croundteam/cround/shortform/application/ShortFormService.java
+++ b/src/main/java/croundteam/cround/shortform/application/ShortFormService.java
@@ -1,5 +1,6 @@
 package croundteam.cround.shortform.application;
 
+import croundteam.cround.shortform.application.dto.FindPopularShortForms;
 import croundteam.cround.support.search.SearchCondition;
 import croundteam.cround.common.exception.ErrorCode;
 import croundteam.cround.creator.domain.Creator;
@@ -24,6 +25,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 import static croundteam.cround.common.fixtures.ConstantFixtures.SHORT_FORM_IMAGE_PATH_PREFIX;
 
@@ -66,6 +69,15 @@ public class ShortFormService {
         ShortForm shortForm = shortFormRepository.findShortFormWithJoinById(shortsId);
 
         return FindShortFormResponse.from(shortForm, member);
+    }
+
+    public FindPopularShortForms findPopularShortForm(int size, AppUser appUser) {
+        Member member = getLoginMember(appUser);
+
+        List<ShortForm> popularLikeShortForms = shortFormQueryRepository.findPopularLikeShortForm(size);
+        List<ShortForm> popularBookmarkShortForms = shortFormQueryRepository.findPopularBookmarkShortForms(size);
+
+        return new FindPopularShortForms(popularLikeShortForms, popularBookmarkShortForms, member);
     }
 
     private Member getLoginMember(AppUser appUser) {

--- a/src/main/java/croundteam/cround/shortform/application/dto/FindPopularShortForms.java
+++ b/src/main/java/croundteam/cround/shortform/application/dto/FindPopularShortForms.java
@@ -1,0 +1,33 @@
+package croundteam.cround.shortform.application.dto;
+
+import croundteam.cround.member.domain.Member;
+import croundteam.cround.shortform.domain.ShortForm;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static croundteam.cround.shortform.application.dto.SearchShortFormResponse.from;
+import static java.util.stream.Collectors.toList;
+
+@Getter
+@NoArgsConstructor
+public class FindPopularShortForms {
+
+    private List<SearchShortFormResponse> popularLikeShortForms = new ArrayList<>();
+    private List<SearchShortFormResponse> popularBookmarkShortForms = new ArrayList<>();
+
+    public FindPopularShortForms(
+            List<ShortForm> highestLikeShortForms,
+            List<ShortForm> popularBookmarkShortForms,
+            Member member
+    ) {
+        this.popularLikeShortForms = convertToSearchShortFormResponse(highestLikeShortForms, member);
+        this.popularBookmarkShortForms = convertToSearchShortFormResponse(popularBookmarkShortForms, member);
+    }
+
+    private static List<SearchShortFormResponse> convertToSearchShortFormResponse(List<ShortForm> shortForms, Member member) {
+        return shortForms.stream().map(shortForm -> from(shortForm, member)).collect(toList());
+    }
+}

--- a/src/main/java/croundteam/cround/shortform/application/dto/FindPopularShortForms.java
+++ b/src/main/java/croundteam/cround/shortform/application/dto/FindPopularShortForms.java
@@ -15,15 +15,18 @@ import static java.util.stream.Collectors.toList;
 @NoArgsConstructor
 public class FindPopularShortForms {
 
+    private List<SearchShortFormResponse> popularVisitShortForms = new ArrayList<>();
     private List<SearchShortFormResponse> popularLikeShortForms = new ArrayList<>();
     private List<SearchShortFormResponse> popularBookmarkShortForms = new ArrayList<>();
 
     public FindPopularShortForms(
-            List<ShortForm> highestLikeShortForms,
+            List<ShortForm> popularVisitShortForms,
+            List<ShortForm> popularLikeShortForms,
             List<ShortForm> popularBookmarkShortForms,
             Member member
     ) {
-        this.popularLikeShortForms = convertToSearchShortFormResponse(highestLikeShortForms, member);
+        this.popularVisitShortForms = convertToSearchShortFormResponse(popularVisitShortForms, member);
+        this.popularLikeShortForms = convertToSearchShortFormResponse(popularLikeShortForms, member);
         this.popularBookmarkShortForms = convertToSearchShortFormResponse(popularBookmarkShortForms, member);
     }
 

--- a/src/main/java/croundteam/cround/shortform/domain/ShortForm.java
+++ b/src/main/java/croundteam/cround/shortform/domain/ShortForm.java
@@ -1,5 +1,6 @@
 package croundteam.cround.shortform.domain;
 
+import com.querydsl.core.annotations.QueryProjection;
 import croundteam.cround.board.domain.Content;
 import croundteam.cround.board.domain.Title;
 import croundteam.cround.common.domain.BaseTime;

--- a/src/main/java/croundteam/cround/shortform/domain/ShortForm.java
+++ b/src/main/java/croundteam/cround/shortform/domain/ShortForm.java
@@ -1,6 +1,5 @@
 package croundteam.cround.shortform.domain;
 
-import com.querydsl.core.annotations.QueryProjection;
 import croundteam.cround.board.domain.Content;
 import croundteam.cround.board.domain.Title;
 import croundteam.cround.common.domain.BaseTime;
@@ -40,6 +39,9 @@ public class ShortForm extends BaseTime {
 
     @Embedded
     private ShortFormUrl shortFormUrl;
+
+    @Column(columnDefinition = "bigint default 0", nullable = false)
+    private long visit;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "creator_id")
@@ -105,6 +107,10 @@ public class ShortForm extends BaseTime {
             return false;
         }
         return creator.isAuthoredBy(member);
+    }
+
+    public void increaseVisit() {
+        visit++;
     }
 
     public int getShortFormBookmarks() {

--- a/src/main/java/croundteam/cround/shortform/domain/ShortFormQueryRepository.java
+++ b/src/main/java/croundteam/cround/shortform/domain/ShortFormQueryRepository.java
@@ -123,6 +123,13 @@ public class ShortFormQueryRepository {
         return convertToSliceFrom(searchCondition.getSize(), shortForms, Pageable.unpaged());
     }
 
+    private BooleanExpression ltCursorId(Long cursorId) {
+        if(cursorId == null) {
+            return null;
+        }
+        return creator.id.lt(cursorId);
+    }
+
     public List<ShortForm> findPopularLikeShortForm(int size) {
         return jpaQueryFactory
                 .selectFrom(shortForm)
@@ -145,10 +152,12 @@ public class ShortFormQueryRepository {
                 .fetch();
     }
 
-    private BooleanExpression ltCursorId(Long cursorId) {
-        if(cursorId == null) {
-            return null;
-        }
-        return creator.id.lt(cursorId);
+    public List<ShortForm> findPopularVisitShortForm(int size) {
+        return jpaQueryFactory
+                .selectFrom(shortForm)
+                .join(shortForm.creator, creator).fetchJoin()
+                .orderBy(shortForm.visit.desc(), shortForm.id.desc())
+                .limit(size)
+                .fetch();
     }
 }

--- a/src/main/java/croundteam/cround/shortform/domain/ShortFormQueryRepository.java
+++ b/src/main/java/croundteam/cround/shortform/domain/ShortFormQueryRepository.java
@@ -123,6 +123,28 @@ public class ShortFormQueryRepository {
         return convertToSliceFrom(searchCondition.getSize(), shortForms, Pageable.unpaged());
     }
 
+    public List<ShortForm> findPopularLikeShortForm(int size) {
+        return jpaQueryFactory
+                .selectFrom(shortForm)
+                .join(shortForm.creator, creator).fetchJoin()
+                .leftJoin(shortFormLike).on(shortForm.id.eq(shortFormLike.shortForm.id))
+                .groupBy(shortForm.id)
+                .orderBy(shortFormLike.shortForm.id.sum().desc(), shortForm.id.desc())
+                .limit(size)
+                .fetch();
+    }
+
+    public List<ShortForm> findPopularBookmarkShortForms(int size) {
+        return jpaQueryFactory
+                .selectFrom(shortForm)
+                .join(shortForm.creator, creator).fetchJoin()
+                .leftJoin(shortFormBookmark).on(shortForm.id.eq(shortFormBookmark.shortForm.id))
+                .groupBy(shortForm.id)
+                .orderBy(shortFormBookmark.shortForm.id.sum().desc(), shortForm.id.desc())
+                .limit(size)
+                .fetch();
+    }
+
     private BooleanExpression ltCursorId(Long cursorId) {
         if(cursorId == null) {
             return null;

--- a/src/main/java/croundteam/cround/shortform/presentation/ShortFormController.java
+++ b/src/main/java/croundteam/cround/shortform/presentation/ShortFormController.java
@@ -1,5 +1,6 @@
 package croundteam.cround.shortform.presentation;
 
+import croundteam.cround.shortform.application.dto.FindPopularShortForms;
 import croundteam.cround.support.search.SearchCondition;
 import croundteam.cround.support.vo.AppUser;
 import croundteam.cround.support.annotation.Authenticated;
@@ -49,5 +50,13 @@ public class ShortFormController {
     @GetMapping("/{shortsId}")
     public ResponseEntity<FindShortFormResponse> findOne(@PathVariable Long shortsId, @Authenticated AppUser appUser) {
         return ResponseEntity.ok(shortFormService.findOne(shortsId, appUser));
+    }
+
+    @GetMapping("/populars")
+    public ResponseEntity<FindPopularShortForms> findPopularShorts(
+            @RequestParam(name = "size", defaultValue = "3") int size,
+            @Authenticated AppUser appUser
+    ) {
+       return ResponseEntity.ok(shortFormService.findPopularShortForm(size, appUser));
     }
 }

--- a/src/main/java/croundteam/cround/support/search/BaseSearchCondition.java
+++ b/src/main/java/croundteam/cround/support/search/BaseSearchCondition.java
@@ -1,16 +1,20 @@
 package croundteam.cround.support.search;
 
-import lombok.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import static croundteam.cround.common.fixtures.ConstantFixtures.DEFAULT_PAGE_SIZE;
 
 @NoArgsConstructor
-@AllArgsConstructor
-@ToString
 @Getter @Setter
 public class BaseSearchCondition {
 
-    private Long cursorId;
+    private long cursorId;
     private int size = DEFAULT_PAGE_SIZE;
 
+    public BaseSearchCondition(long cursorId, int size) {
+        this.cursorId = cursorId;
+        this.size = size;
+    }
 }


### PR DESCRIPTION
## 기능 설명
- 메인페이지 크리에이터 항목 추가 (최신순, 맞춤별, 랜덤별)
- 숏클래스 인기 항목 추가 (조회수순, 좋아요순, 북마크순)