### PR TITLE
feat: 비밀번호 찾기 기능을 추가한다 (#137)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,4 +42,5 @@ out/
 /src/main/resources/application-oauth.yml
 /src/main/resources/application-aws.yml
 /src/main/resources/application-rds.yml
+/src/main/resources/application-mail.yml
 /api/http/**

--- a/build.gradle
+++ b/build.gradle
@@ -29,10 +29,13 @@ dependencies {
 
 	implementation 'com.querydsl:querydsl-jpa'
 	implementation 'com.querydsl:querydsl-apt'
+
 	implementation 'org.flywaydb:flyway-core'
 	implementation 'org.flywaydb:flyway-mysql'
 
 	implementation("com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.5.8")
+
+	implementation'org.springframework.boot:spring-boot-starter-mail'
 
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/croundteam/cround/common/exception/ErrorCode.java
+++ b/src/main/java/croundteam/cround/common/exception/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
      */
     INVALID_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "인증에 실패하였습니다."),
     INCORRECT_SOURCE(HttpStatus.UNAUTHORIZED, "동일한 요청자가 아닙니다."),
+    INVALID_AUTHORIZATION_CODE(HttpStatus.UNAUTHORIZED, "올바른 사용자가 아닙니다."),
 
     /**
      * 403 Forbidden

--- a/src/main/java/croundteam/cround/common/exception/ErrorCode.java
+++ b/src/main/java/croundteam/cround/common/exception/ErrorCode.java
@@ -61,7 +61,8 @@ public enum ErrorCode {
     /**
      * 500 INTERNAL SERVER ERROR
      */
-    UPLOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "파일을 S3에 저장 실패 하였습니다.");
+    UPLOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "파일을 S3에 저장 실패하였습니다."),
+    EMAIL_SEND(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패하였습니다.");
 
 
     private final HttpStatus status;

--- a/src/main/java/croundteam/cround/common/fixtures/ConstantFixtures.java
+++ b/src/main/java/croundteam/cround/common/fixtures/ConstantFixtures.java
@@ -18,7 +18,4 @@ public final class ConstantFixtures {
     public static final int DEFAULT_PAGE_SIZE = 5;
 
     public static final String PASSWORD_CHANGE_SUBJECT_MESSAGE = "[크라운드] 비밀번호 찾기 링크입니다.";
-    public static final String PASSWORD_CHANGE_TEXT_PREFIX = "<h2>비밀번호 재설정 링크를 보내드립니다.</h2><br/><a href='https://cround-client.vercel.app/password/new?id=";
-    public static final String PASSWORD_CHANGE_TEXT_SUFFIX = "'>\uD83D\uDC49 비밀번호 재설정하기</a><br/><br/>";
-
 }

--- a/src/main/java/croundteam/cround/common/fixtures/ConstantFixtures.java
+++ b/src/main/java/croundteam/cround/common/fixtures/ConstantFixtures.java
@@ -16,4 +16,7 @@ public final class ConstantFixtures {
     public static final int CREATOR_PLATFORM_THEME_LENGTH_MAX_SIZE = 10;
 
     public static final int DEFAULT_PAGE_SIZE = 5;
+
+    public static final String PASSWORD_CHANGE_SUBJECT_MESSAGE = "[크라운드] 비밀번호 찾기 링크입니다.";
+    public static final String PASSWORD_CHANGE_TEXT_MESSAGE = "<h2>비밀번호 재설정 링크를 보내드립니다.</h2><br/><a href='https://cround-client.vercel.app/password/new'>\uD83D\uDC49 비밀번호 재설정하기</a><br/><br/>";
 }

--- a/src/main/java/croundteam/cround/common/fixtures/ConstantFixtures.java
+++ b/src/main/java/croundteam/cround/common/fixtures/ConstantFixtures.java
@@ -18,5 +18,7 @@ public final class ConstantFixtures {
     public static final int DEFAULT_PAGE_SIZE = 5;
 
     public static final String PASSWORD_CHANGE_SUBJECT_MESSAGE = "[크라운드] 비밀번호 찾기 링크입니다.";
-    public static final String PASSWORD_CHANGE_TEXT_MESSAGE = "<h2>비밀번호 재설정 링크를 보내드립니다.</h2><br/><a href='https://cround-client.vercel.app/password/new'>\uD83D\uDC49 비밀번호 재설정하기</a><br/><br/>";
+    public static final String PASSWORD_CHANGE_TEXT_PREFIX = "<h2>비밀번호 재설정 링크를 보내드립니다.</h2><br/><a href='https://cround-client.vercel.app/password/new?id=";
+    public static final String PASSWORD_CHANGE_TEXT_SUFFIX = "'>\uD83D\uDC49 비밀번호 재설정하기</a><br/><br/>";
+
 }

--- a/src/main/java/croundteam/cround/common/fixtures/ValidationMessages.java
+++ b/src/main/java/croundteam/cround/common/fixtures/ValidationMessages.java
@@ -10,6 +10,7 @@ public final class ValidationMessages {
     public static final String MEMBER_NICKNAME_MESSAGE = "닉네임은 2~6글자로 영어, 한글, 숫자만 가능합니다.";
     public static final String MEMBER_PASSWORD_MESSAGE = "비밀번호는 영어 대소문자, 숫자, 특수문자를 포함한 8~20자만 가능합니다.";
     public static final String MESSAGE_TEXT_EMPTY_MESSAGE = "쪽지 내용은 공백일 수 없습니다.";
+    public static final String ID_TEXT_EMPTY_MESSAGE = "회원의 아이디는 공백일 수 없습니다.";
     public static final String MESSAGE_RECEIVER_EMPTY_MESSAGE = "쪽지의 대상은 공백일 수 없습니다.";
 
     public static final String MEMBER_NAME_FORMAT = "^[^a-zA-Z]{2,6}$";

--- a/src/main/java/croundteam/cround/config/SecurityConfig.java
+++ b/src/main/java/croundteam/cround/config/SecurityConfig.java
@@ -70,8 +70,10 @@ public class SecurityConfig {
                         "/api/creators/{creatorId}/reviews", "/api/creators/{creatorId}/boards",
                         "/api/creators/{creatorId}/shorts", "/api/creators/home")
                 .permitAll()
-                .antMatchers(HttpMethod.POST, "/auth/login", "/api/members",
+                .antMatchers(HttpMethod.POST, "/auth/login", "/api/members", "/api/members/me/password",
                         "/api/members/validations/email", "/api/members/validations/nickname").permitAll()
+                .antMatchers(HttpMethod.PATCH, "/api/members/me/password").permitAll()
+
                 .anyRequest().authenticated();
 
         http

--- a/src/main/java/croundteam/cround/creator/domain/Creator.java
+++ b/src/main/java/croundteam/cround/creator/domain/Creator.java
@@ -27,7 +27,6 @@ import static croundteam.cround.creator.domain.tag.Tags.castToTags;
 @Table(uniqueConstraints = @UniqueConstraint(name = "creator_member_unique", columnNames = "member_id"),
         indexes = @Index(name = "idx_creator_nickname", columnList = "nickname", unique = true))
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@EqualsAndHashCode
 public class Creator extends BaseTime {
 
     @Id

--- a/src/main/java/croundteam/cround/member/application/AuthService.java
+++ b/src/main/java/croundteam/cround/member/application/AuthService.java
@@ -53,7 +53,7 @@ public class AuthService {
 
         Creator creator = findCreatorByMember(member);
 
-        return new LoginSuccessResponse(tokenResponse, member.getRoleName(), creator);
+        return new LoginSuccessResponse(tokenResponse, member, creator);
     }
 
     private Creator findCreatorByMember(Member member) {
@@ -76,7 +76,7 @@ public class AuthService {
 
         Creator creator = findCreatorByMember(member);
 
-        return new LoginSuccessResponse(tokenResponse, member.getRoleName(), creator);
+        return new LoginSuccessResponse(tokenResponse, member, creator);
     }
 
     private Member saveOrUpdate(OAuthAttributes attributes) {

--- a/src/main/java/croundteam/cround/member/application/MailService.java
+++ b/src/main/java/croundteam/cround/member/application/MailService.java
@@ -1,0 +1,7 @@
+package croundteam.cround.member.application;
+
+public interface MailService {
+
+    void send(String email, String type);
+
+}

--- a/src/main/java/croundteam/cround/member/application/MailServiceImpl.java
+++ b/src/main/java/croundteam/cround/member/application/MailServiceImpl.java
@@ -9,10 +9,10 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
@@ -24,15 +24,14 @@ import static croundteam.cround.common.fixtures.ConstantFixtures.*;
 @Slf4j
 public class MailServiceImpl implements MailService {
 
-    @Value("${spring.mail.from}")
-    private String sender;
-
     private final JavaMailSender javaMailSender;
     private final MemberRepository memberRepository;
 
     @Override
+    @Transactional
     public void send(String email, String type) {
         Member member = findMemberByEmail(email);
+        member.issueAuthorizationCode();
 
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
         setMimeMessage(mimeMessage, member, type);
@@ -53,29 +52,31 @@ public class MailServiceImpl implements MailService {
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
             mimeMessageHelper.setTo(member.getEmail());
             mimeMessageHelper.setSubject(mailType.getText());
-            mimeMessageHelper.setText(appendMailTextAndId(mailType, member), true);
+            mimeMessageHelper.setText(mailType.appendText(member.getId(), member.getAuthorizationCode()), true);
         } catch (MessagingException e) {
             log.error("[MailService.send()] 메일 전송 실패");
             throw new EmailSendException(ErrorCode.EMAIL_SEND);
         }
     }
 
-    private String appendMailTextAndId(MailType mailType, Member member) {
-        return mailType.getPrefix() + member.getId() + mailType.getSuffix();
-    }
-
     @Getter
     @AllArgsConstructor
     public enum MailType {
 
-        PASSWORD(PASSWORD_CHANGE_SUBJECT_MESSAGE, PASSWORD_CHANGE_TEXT_PREFIX, PASSWORD_CHANGE_TEXT_SUFFIX);
+        PASSWORD(PASSWORD_CHANGE_SUBJECT_MESSAGE) {
+            @Override
+            public String appendText(Long id, String code) {
+                return "<h2>비밀번호 재설정 링크를 보내드립니다.</h2><br/><a href='https://cround-client.vercel.app/password/new" +
+                        "?id=" + id + "&code=" + code + "'>\uD83D\uDC49 비밀번호 재설정하기</a><br/><br/>";
+            }
+        };
 
         private final String text;
-        private final String prefix;
-        private final String suffix;
 
         public static MailType getMailType(String type) {
             return MailType.valueOf(type.toUpperCase());
         }
+
+        public abstract String appendText(Long id, String code);
     }
 }

--- a/src/main/java/croundteam/cround/member/application/MailServiceImpl.java
+++ b/src/main/java/croundteam/cround/member/application/MailServiceImpl.java
@@ -1,9 +1,12 @@
 package croundteam.cround.member.application;
 
-import croundteam.cround.support.search.SearchCondition;
+import croundteam.cround.common.exception.ErrorCode;
+import croundteam.cround.member.exception.EmailSendException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Service;
@@ -11,47 +14,54 @@ import org.springframework.stereotype.Service;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
+import static croundteam.cround.common.fixtures.ConstantFixtures.PASSWORD_CHANGE_SUBJECT_MESSAGE;
+import static croundteam.cround.common.fixtures.ConstantFixtures.PASSWORD_CHANGE_TEXT_MESSAGE;
+
 @Service
+@RequiredArgsConstructor
+@Slf4j
 public class MailServiceImpl implements MailService {
 
-    private final JavaMailSender javaMailSender;
+    @Value("${spring.mail.from}")
+    private String sender;
 
-    public MailServiceImpl(JavaMailSender javaMailSender) {
-        this.javaMailSender = javaMailSender;
-    }
+    private final JavaMailSender javaMailSender;
 
     @Override
     public void send(String email, String type) {
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
-        System.out.println("mimeMessage = " + mimeMessage);
-
-        MimeMessageHelper helper = getMimeMessage(mimeMessage ,email, type);
+        setMimeMessage(mimeMessage, email, type);
 
         javaMailSender.send(mimeMessage);
     }
 
-    private MimeMessageHelper getMimeMessage(MimeMessage mimeMessage, String email, String type) {
+    private void setMimeMessage(MimeMessage mimeMessage, String email, String type) {
         try {
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
             mimeMessageHelper.setTo(email);
-            mimeMessageHelper.setSubject(SubjectType.getText(type));
-            mimeMessageHelper.setText("<h1>이메일 전송 테스트</h1>", true);
-
-            return mimeMessageHelper;
+            mimeMessageHelper.setSubject(MailType.getText(type));
+            mimeMessageHelper.setText(MailType.getMessage(type), true);
         } catch (MessagingException e) {
-            throw new RuntimeException(e);
+            log.error("[MailService.send()] 메일 전송 실패");
+            throw new EmailSendException(ErrorCode.EMAIL_SEND);
         }
     }
 
     @Getter
     @AllArgsConstructor
-    public enum SubjectType {
-        PASSWORD("[크라운드] 비밀번호 찾기 링크입니다.");
+    public enum MailType {
+
+        PASSWORD(PASSWORD_CHANGE_SUBJECT_MESSAGE, PASSWORD_CHANGE_TEXT_MESSAGE);
 
         private String text;
+        private String message;
 
         public static String getText(String type) {
-            return SubjectType.valueOf(type.toUpperCase()).getText();
+            return MailType.valueOf(type.toUpperCase()).getText();
+        }
+
+        public static String getMessage(String type) {
+            return MailType.valueOf(type.toUpperCase()).getMessage();
         }
     }
 }

--- a/src/main/java/croundteam/cround/member/application/MailServiceImpl.java
+++ b/src/main/java/croundteam/cround/member/application/MailServiceImpl.java
@@ -1,0 +1,57 @@
+package croundteam.cround.member.application;
+
+import croundteam.cround.support.search.SearchCondition;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.stereotype.Service;
+
+import javax.mail.MessagingException;
+import javax.mail.internet.MimeMessage;
+
+@Service
+public class MailServiceImpl implements MailService {
+
+    private final JavaMailSender javaMailSender;
+
+    public MailServiceImpl(JavaMailSender javaMailSender) {
+        this.javaMailSender = javaMailSender;
+    }
+
+    @Override
+    public void send(String email, String type) {
+        MimeMessage mimeMessage = javaMailSender.createMimeMessage();
+        System.out.println("mimeMessage = " + mimeMessage);
+
+        MimeMessageHelper helper = getMimeMessage(mimeMessage ,email, type);
+
+        javaMailSender.send(mimeMessage);
+    }
+
+    private MimeMessageHelper getMimeMessage(MimeMessage mimeMessage, String email, String type) {
+        try {
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
+            mimeMessageHelper.setTo(email);
+            mimeMessageHelper.setSubject(SubjectType.getText(type));
+            mimeMessageHelper.setText("<h1>이메일 전송 테스트</h1>", true);
+
+            return mimeMessageHelper;
+        } catch (MessagingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public enum SubjectType {
+        PASSWORD("[크라운드] 비밀번호 찾기 링크입니다.");
+
+        private String text;
+
+        public static String getText(String type) {
+            return SubjectType.valueOf(type.toUpperCase()).getText();
+        }
+    }
+}

--- a/src/main/java/croundteam/cround/member/application/MailServiceImpl.java
+++ b/src/main/java/croundteam/cround/member/application/MailServiceImpl.java
@@ -1,7 +1,10 @@
 package croundteam.cround.member.application;
 
 import croundteam.cround.common.exception.ErrorCode;
+import croundteam.cround.member.domain.Member;
+import croundteam.cround.member.domain.MemberRepository;
 import croundteam.cround.member.exception.EmailSendException;
+import croundteam.cround.member.exception.NotExistMemberException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -14,8 +17,7 @@ import org.springframework.stereotype.Service;
 import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
-import static croundteam.cround.common.fixtures.ConstantFixtures.PASSWORD_CHANGE_SUBJECT_MESSAGE;
-import static croundteam.cround.common.fixtures.ConstantFixtures.PASSWORD_CHANGE_TEXT_MESSAGE;
+import static croundteam.cround.common.fixtures.ConstantFixtures.*;
 
 @Service
 @RequiredArgsConstructor
@@ -26,37 +28,51 @@ public class MailServiceImpl implements MailService {
     private String sender;
 
     private final JavaMailSender javaMailSender;
+    private final MemberRepository memberRepository;
 
     @Override
     public void send(String email, String type) {
+        Member member = findMemberByEmail(email);
+
         MimeMessage mimeMessage = javaMailSender.createMimeMessage();
-        setMimeMessage(mimeMessage, email, type);
+        setMimeMessage(mimeMessage, member, type);
 
         javaMailSender.send(mimeMessage);
     }
 
-    private void setMimeMessage(MimeMessage mimeMessage, String email, String type) {
+    private Member findMemberByEmail(String email) {
+        return memberRepository.findByEmail(email).orElseThrow(() -> {
+            throw new NotExistMemberException(ErrorCode.NOT_EXIST_MEMBER);
+        });
+    }
+
+    private void setMimeMessage(MimeMessage mimeMessage, Member member, String type) {
         try {
             MailType mailType = MailType.getMailType(type);
 
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
-            mimeMessageHelper.setTo(email);
+            mimeMessageHelper.setTo(member.getEmail());
             mimeMessageHelper.setSubject(mailType.getText());
-            mimeMessageHelper.setText(mailType.getMessage(), true);
+            mimeMessageHelper.setText(appendMailTextAndId(mailType, member), true);
         } catch (MessagingException e) {
             log.error("[MailService.send()] 메일 전송 실패");
             throw new EmailSendException(ErrorCode.EMAIL_SEND);
         }
     }
 
+    private String appendMailTextAndId(MailType mailType, Member member) {
+        return mailType.getPrefix() + member.getId() + mailType.getSuffix();
+    }
+
     @Getter
     @AllArgsConstructor
     public enum MailType {
 
-        PASSWORD(PASSWORD_CHANGE_SUBJECT_MESSAGE, PASSWORD_CHANGE_TEXT_MESSAGE);
+        PASSWORD(PASSWORD_CHANGE_SUBJECT_MESSAGE, PASSWORD_CHANGE_TEXT_PREFIX, PASSWORD_CHANGE_TEXT_SUFFIX);
 
         private final String text;
-        private final String message;
+        private final String prefix;
+        private final String suffix;
 
         public static MailType getMailType(String type) {
             return MailType.valueOf(type.toUpperCase());

--- a/src/main/java/croundteam/cround/member/application/MailServiceImpl.java
+++ b/src/main/java/croundteam/cround/member/application/MailServiceImpl.java
@@ -37,10 +37,12 @@ public class MailServiceImpl implements MailService {
 
     private void setMimeMessage(MimeMessage mimeMessage, String email, String type) {
         try {
+            MailType mailType = MailType.getMailType(type);
+
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, false, "UTF-8");
             mimeMessageHelper.setTo(email);
-            mimeMessageHelper.setSubject(MailType.getText(type));
-            mimeMessageHelper.setText(MailType.getMessage(type), true);
+            mimeMessageHelper.setSubject(mailType.getText());
+            mimeMessageHelper.setText(mailType.getMessage(), true);
         } catch (MessagingException e) {
             log.error("[MailService.send()] 메일 전송 실패");
             throw new EmailSendException(ErrorCode.EMAIL_SEND);
@@ -53,15 +55,11 @@ public class MailServiceImpl implements MailService {
 
         PASSWORD(PASSWORD_CHANGE_SUBJECT_MESSAGE, PASSWORD_CHANGE_TEXT_MESSAGE);
 
-        private String text;
-        private String message;
+        private final String text;
+        private final String message;
 
-        public static String getText(String type) {
-            return MailType.valueOf(type.toUpperCase()).getText();
-        }
-
-        public static String getMessage(String type) {
-            return MailType.valueOf(type.toUpperCase()).getMessage();
+        public static MailType getMailType(String type) {
+            return MailType.valueOf(type.toUpperCase());
         }
     }
 }

--- a/src/main/java/croundteam/cround/member/application/dto/FindMemberResponse.java
+++ b/src/main/java/croundteam/cround/member/application/dto/FindMemberResponse.java
@@ -1,6 +1,5 @@
 package croundteam.cround.member.application.dto;
 
-import croundteam.cround.creator.domain.platform.PlatformType;
 import croundteam.cround.member.domain.Member;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/croundteam/cround/member/application/dto/LoginResponse.java
+++ b/src/main/java/croundteam/cround/member/application/dto/LoginResponse.java
@@ -9,19 +9,25 @@ public class LoginResponse {
 
     private String accessToken;
     private String roleName;
+    private String nickname;
     private String profileImage;
     private Long creatorId;
+    private boolean isSocialLogin;
 
-    public LoginResponse(String accessToken, String roleName, String profileImage, Long creatorId) {
+    public LoginResponse(String accessToken, String roleName, String nickname, String profileImage,
+                         Long creatorId, boolean isSocialLogin) {
         this.accessToken = accessToken;
         this.roleName = roleName;
+        this.nickname = nickname;
         this.profileImage = profileImage;
         this.creatorId = creatorId;
+        this.isSocialLogin = isSocialLogin;
     }
 
     public static LoginResponse create(LoginSuccessResponse loginSuccessResponse) {
         return new LoginResponse(
                 loginSuccessResponse.extractByAccessToken(), loginSuccessResponse.getRoleName(),
-                loginSuccessResponse.getProfileImage(), loginSuccessResponse.getCreatorId());
+                loginSuccessResponse.getNickname(), loginSuccessResponse.getProfileImage(),
+                loginSuccessResponse.getCreatorId(), loginSuccessResponse.isSocialLogin());
     }
 }

--- a/src/main/java/croundteam/cround/member/application/dto/LoginSuccessResponse.java
+++ b/src/main/java/croundteam/cround/member/application/dto/LoginSuccessResponse.java
@@ -1,6 +1,7 @@
 package croundteam.cround.member.application.dto;
 
 import croundteam.cround.creator.domain.Creator;
+import croundteam.cround.member.domain.Member;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,17 +14,28 @@ public class LoginSuccessResponse {
     private String accessToken;
     private String refreshToken;
     private String roleName;
+    private String nickname;
+    private boolean isSocialLogin;
     private String profileImage;
     private Long creatorId;
 
-    public LoginSuccessResponse(TokenResponse tokenResponse, String roleName, Creator creator) {
+    public LoginSuccessResponse(TokenResponse tokenResponse, Member member, Creator creator) {
         this.accessToken = tokenResponse.getAccessToken();
         this.refreshToken = tokenResponse.getRefreshToken();
-        this.roleName = roleName;
+        this.roleName = member.getRoleName();
+        this.nickname = getCurrentUserNickname(member, creator);
+        this.isSocialLogin = member.isSocial();
         if(Objects.nonNull(creator)) {
             this.profileImage = creator.getProfileImage();
             this.creatorId = creator.getId();
         }
+    }
+
+    private String getCurrentUserNickname(Member member, Creator creator) {
+        if(Objects.nonNull(creator)) {
+            return creator.getNickname();
+        }
+        return member.getNickname();
     }
 
     public String extractByAccessToken() {

--- a/src/main/java/croundteam/cround/member/application/dto/PasswordChangeRequest.java
+++ b/src/main/java/croundteam/cround/member/application/dto/PasswordChangeRequest.java
@@ -1,0 +1,36 @@
+package croundteam.cround.member.application.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import static croundteam.cround.common.fixtures.ValidationMessages.EMPTY_MESSAGE;
+import static croundteam.cround.common.fixtures.ValidationMessages.ID_TEXT_EMPTY_MESSAGE;
+
+@Getter
+@NoArgsConstructor
+public class PasswordChangeRequest {
+
+    @NotNull(message = ID_TEXT_EMPTY_MESSAGE)
+    private Long id;
+
+    @NotBlank(message = EMPTY_MESSAGE)
+    private String code;
+
+    @NotBlank(message = EMPTY_MESSAGE)
+//    @Pattern(regexp = MEMBER_PASSWORD_FORMAT, message = MEMBER_PASSWORD_MESSAGE)
+    private String password;
+
+    @NotBlank(message = EMPTY_MESSAGE)
+//    @Pattern(regexp = MEMBER_PASSWORD_FORMAT, message = MEMBER_PASSWORD_MESSAGE)
+    private String confirmPassword;
+
+    public PasswordChangeRequest(Long id, String code, String password, String confirmPassword) {
+        this.id = id;
+        this.code = code;
+        this.password = password;
+        this.confirmPassword = confirmPassword;
+    }
+}

--- a/src/main/java/croundteam/cround/member/domain/AuthProvider.java
+++ b/src/main/java/croundteam/cround/member/domain/AuthProvider.java
@@ -1,5 +1,10 @@
 package croundteam.cround.member.domain;
 
 public enum AuthProvider {
-    LOCAL, KAKAO
+    LOCAL, KAKAO;
+
+    public boolean isSocial() {
+        return !LOCAL.equals(this);
+    }
+
 }

--- a/src/main/java/croundteam/cround/member/domain/Member.java
+++ b/src/main/java/croundteam/cround/member/domain/Member.java
@@ -1,9 +1,11 @@
 package croundteam.cround.member.domain;
 
 import croundteam.cround.common.domain.BaseTime;
+import croundteam.cround.common.exception.ErrorCode;
 import croundteam.cround.creator.domain.Creator;
 import croundteam.cround.follow.domain.Followings;
 import croundteam.cround.member.application.dto.MemberUpdateRequest;
+import croundteam.cround.member.exception.InvalidAuthorizationCodeException;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,6 +13,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -37,6 +40,8 @@ public class Member extends BaseTime {
     @Column(length = 128)
     private String password;
 
+    private String authorizationCode;
+
     @Embedded
     private InterestPlatforms interestPlatforms;
 
@@ -59,6 +64,10 @@ public class Member extends BaseTime {
         this.interestPlatforms = interestPlatforms;
         this.role = Role.USER;
         this.authProvider = authProvider;
+    }
+
+    public void changePassword(String password) {
+        this.password = password;
     }
 
     public void update(Member member) {
@@ -100,5 +109,15 @@ public class Member extends BaseTime {
 
     public List<String> getInterestPlatforms() {
         return interestPlatforms.castPlatformTypes();
+    }
+
+    public void issueAuthorizationCode() {
+        this.authorizationCode = UUID.randomUUID().toString();
+    }
+
+    public void validateAuthorizationCode(String code) {
+        if(code.isBlank() || !code.equals(authorizationCode)) {
+            throw new InvalidAuthorizationCodeException(ErrorCode.INVALID_AUTHORIZATION_CODE);
+        }
     }
 }

--- a/src/main/java/croundteam/cround/member/domain/Member.java
+++ b/src/main/java/croundteam/cround/member/domain/Member.java
@@ -71,6 +71,13 @@ public class Member extends BaseTime {
         this.interestPlatforms = InterestPlatforms.create(memberUpdateRequest.getInterestPlatforms());
     }
 
+    public boolean isSocial() {
+        if (authProvider.isSocial()) {
+            return true;
+        }
+        return false;
+    }
+
     public void follow(Creator target) {
         followings.follow(this, target);
     }

--- a/src/main/java/croundteam/cround/member/exception/EmailSendException.java
+++ b/src/main/java/croundteam/cround/member/exception/EmailSendException.java
@@ -1,0 +1,10 @@
+package croundteam.cround.member.exception;
+
+import croundteam.cround.common.exception.BusinessException;
+import croundteam.cround.common.exception.ErrorCode;
+
+public class EmailSendException extends BusinessException {
+    public EmailSendException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/croundteam/cround/member/exception/InvalidAuthorizationCodeException.java
+++ b/src/main/java/croundteam/cround/member/exception/InvalidAuthorizationCodeException.java
@@ -1,0 +1,10 @@
+package croundteam.cround.member.exception;
+
+import croundteam.cround.common.exception.BusinessException;
+import croundteam.cround.common.exception.ErrorCode;
+
+public class InvalidAuthorizationCodeException extends BusinessException {
+    public InvalidAuthorizationCodeException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/croundteam/cround/member/presentation/MemberController.java
+++ b/src/main/java/croundteam/cround/member/presentation/MemberController.java
@@ -2,6 +2,7 @@ package croundteam.cround.member.presentation;
 
 import croundteam.cround.board.application.dto.SearchBoardsResponses;
 import croundteam.cround.creator.application.dto.SearchCreatorResponses;
+import croundteam.cround.member.application.MailService;
 import croundteam.cround.member.application.MemberService;
 import croundteam.cround.member.application.dto.*;
 import croundteam.cround.shortform.application.dto.SearchShortFormResponses;
@@ -19,9 +20,13 @@ import java.net.URI;
 public class MemberController {
 
     private final MemberService memberService;
+    private final MailService mailService;
 
-    public MemberController(MemberService memberService) {
+    private final String PASSWORD = "PASSWORD";
+
+    public MemberController(MemberService memberService, MailService mailService) {
         this.memberService = memberService;
+        this.mailService = mailService;
     }
 
     @PostMapping
@@ -75,8 +80,25 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
-//    @PatchMapping("/me")
-//    public
+    @PostMapping("/me/password")
+    public ResponseEntity<Void> sendMailForChangePassword(
+            @RequestBody @Valid final EmailValidationRequest emailValidationRequest
+    ) {
+        String email = emailValidationRequest.getEmail();
+
+        memberService.findMemberByEmail(email);
+        mailService.send(email, PASSWORD);
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/me/password")
+    public ResponseEntity<Void> changePasswordByMailCertification(
+            @RequestBody @Valid final PasswordChangeRequest passwordChangeRequest
+    ) {
+        memberService.changePasswordByMailCertification(passwordChangeRequest);
+        return ResponseEntity.ok().build();
+    }
 
     @PostMapping("/validations/email")
     public ResponseEntity<Void> validateEmail(

--- a/src/main/java/croundteam/cround/member/presentation/MemberController.java
+++ b/src/main/java/croundteam/cround/member/presentation/MemberController.java
@@ -75,6 +75,9 @@ public class MemberController {
         return ResponseEntity.ok().build();
     }
 
+//    @PatchMapping("/me")
+//    public
+
     @PostMapping("/validations/email")
     public ResponseEntity<Void> validateEmail(
             @RequestBody @Valid final EmailValidationRequest emailValidationRequest

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,4 +6,4 @@ spring:
       prod:
         - flyway
         - rds
-    include: security-common, oauth, aws
+    include: security-common, oauth, aws, mail

--- a/src/test/java/croundteam/cround/member/application/MailServiceImplTest.java
+++ b/src/test/java/croundteam/cround/member/application/MailServiceImplTest.java
@@ -5,8 +5,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Profile;
 
-import static org.junit.jupiter.api.Assertions.*;
-
 @SpringBootTest
 @Profile("test")
 class MailServiceImplTest {
@@ -17,7 +15,6 @@ class MailServiceImplTest {
     @Test
     void sendTest() {
         mailService.send("jaesa5221@gmail.com", "password");
-
     }
 
 }

--- a/src/test/java/croundteam/cround/member/application/MailServiceImplTest.java
+++ b/src/test/java/croundteam/cround/member/application/MailServiceImplTest.java
@@ -1,0 +1,23 @@
+package croundteam.cround.member.application;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Profile;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Profile("test")
+class MailServiceImplTest {
+
+    @Autowired
+    protected MailService mailService;
+
+    @Test
+    void sendTest() {
+        mailService.send("jaesa5221@gmail.com", "password");
+
+    }
+
+}

--- a/src/test/java/croundteam/cround/member/application/MailServiceImplTest.java
+++ b/src/test/java/croundteam/cround/member/application/MailServiceImplTest.java
@@ -14,7 +14,8 @@ class MailServiceImplTest {
 
     @Test
     void sendTest() {
-        mailService.send("jaesa5221@gmail.com", "password");
+        mailService.send("cround@cround.com", "password");
+
     }
 
 }


### PR DESCRIPTION
## 기능 설명
- Spring의 기능 중 MailSender의 하위 인터페이스인 JavaMailSender를 활용하여 기능 추가

## 기능 상세
- [x] 이메일 전송 실패시 customize한 예외 발생
- [x] 추후 이메일이 확장될 수 있음에 따라 메일 유형(MailType)을 Enum으로 관리
- [x] 올바른 요청자인지 구분하기 위해 검증하는 필드(authorizationCode)를 Member에 추가하고 검증하도록 구현

